### PR TITLE
Property changed now lazy and stops on disconnect.

### DIFF
--- a/src/types/VoicemeeterTypes.ts
+++ b/src/types/VoicemeeterTypes.ts
@@ -21,3 +21,19 @@ export interface Device {
 	hardwareId: string;
 	type: number;
 }
+
+/**
+ * Options for connecting to VoiceMeeter.
+ *
+ * @export
+ * @interface ConnectOptions
+ */
+export interface ConnectOptions {
+	/**
+	 * The amount of milliseconds between each check for changed parameters.
+	 *
+	 * @type {number}
+	 * @memberof ConnectOptions
+	 */
+	propertyChangedInterval?: number;
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The polling for property change is great, but has three major drawbacks that this PR solves without any breaking changes.


* **What is the current behavior?** (You can also link to an open issue here)
1. The interval is very aggressive (10ms)
2. It starts polling immediately despite no handlers being attached.
3. Disconnect does not stop the polling.


* **What is the new behavior (if this is a feature change)?**
1. The interval is optionally configurable (still defaults to 10ms)
2. It does not start polling until at least one handler has been attached.
3. Disconnect now stops the polling interval and clears the handlers.


* **Other information**:
Like I said, this is a features but I think this can make it just a bit better and probably a little more performant.
