### PR TITLE
feat: add .setOption

### DIFF
--- a/example/javascript_example.js
+++ b/example/javascript_example.js
@@ -21,6 +21,9 @@ Voicemeeter.init().then(async (vm) => {
 	// Disable VBAN
 	await vm.setOption('vban.Enable=0;');
 
+	// Get vban state
+	console.log(vm.getOption('vban.Enable'));
+
 	// Disconnect voicemeeter client
 	setTimeout(() => {
 		vm.disconnect();

--- a/example/javascript_example.mjs
+++ b/example/javascript_example.mjs
@@ -20,6 +20,9 @@ Voicemeeter.init().then(async (vm) => {
 	// Disable VBAN
 	await vm.setOption('vban.Enable=0;');
 
+	// Get vban state
+	console.log(vm.getOption('vban.Enable'));
+
 	// Disconnect voicemeeter client
 	setTimeout(() => {
 		vm.disconnect();

--- a/example/typescript_example.ts
+++ b/example/typescript_example.ts
@@ -20,6 +20,9 @@ Voicemeeter.init().then(async (vm) => {
 	// Disable VBAN
 	await vm.setOption('vban.Enable=0;');
 
+	// Get vban state
+	console.log(vm.getOption('vban.Enable'));
+
 	vm.attachChangeEvent(() => {
 		console.log("Something changed!");
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "voicemeeter-connector",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "A Connector to use the Voicemeeter API",
 	"repository": "https://github.com/ChewbaccaCookie/voicemeeter-connector",
 	"license": "MIT",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a `getOption` method that gets other parameters available in the remote api, feel like it should be a thing with `.setOption` existing :)


* **What is the current behavior?** (You can also link to an open issue here)
- Not available


* **What is the new behavior (if this is a feature change)?**
- You can now get all parameters from voicemeeter


* **Other information**:
I don't personally agree with the naming of the method `setOption`, I feel like it should just be `setParameter` as that's what voicemeeter also uses ([VoicemeeterRemoteAPI.pdf](https://download.vb-audio.com/Download_CABLE/VoicemeeterRemoteAPI.pdf)), but I've decided to just stick to the name 'option' established by https://github.com/ChewbaccaCookie/voicemeeter-connector/pull/31.

This would also resolve https://github.com/ChewbaccaCookie/voicemeeter-connector/issues/34