### PR TITLE
feat: add .getLevel 

### DIFF
--- a/example/javascript_example.js
+++ b/example/javascript_example.js
@@ -24,6 +24,9 @@ Voicemeeter.init().then(async (vm) => {
 	// Get vban state
 	console.log(vm.getOption('vban.Enable'));
 
+	// Gets current audio levels of strip 0
+    console.log(`Left: ${vm.getLevel(0, 0)} Right: ${vm.getLevel(0, 1)}`);
+
 	// Disconnect voicemeeter client
 	setTimeout(() => {
 		vm.disconnect();

--- a/example/javascript_example.mjs
+++ b/example/javascript_example.mjs
@@ -23,6 +23,9 @@ Voicemeeter.init().then(async (vm) => {
 	// Get vban state
 	console.log(vm.getOption('vban.Enable'));
 
+	// Gets current audio levels of strip 0
+	console.log(`Left: ${vm.getLevel(0, 0)} Right: ${vm.getLevel(0, 1)}`);
+
 	// Disconnect voicemeeter client
 	setTimeout(() => {
 		vm.disconnect();

--- a/example/typescript_example.ts
+++ b/example/typescript_example.ts
@@ -23,6 +23,10 @@ Voicemeeter.init().then(async (vm) => {
 	// Get vban state
 	console.log(vm.getOption('vban.Enable'));
 
+	// Gets current audio levels of strip 0
+    console.log(`Left: ${vm.getLevel(0, 0)} Right: ${vm.getLevel(0, 1)}`);
+
+
 	vm.attachChangeEvent(() => {
 		console.log("Something changed!");
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "voicemeeter-connector",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "A Connector to use the Voicemeeter API",
 	"repository": "https://github.com/ChewbaccaCookie/voicemeeter-connector",
 	"license": "MIT",

--- a/src/lib/VoicemeeterConnector.ts
+++ b/src/lib/VoicemeeterConnector.ts
@@ -42,6 +42,7 @@ export default class Voicemeeter {
 				VBVMR_Logout: ["long", []],
 				VBVMR_RunVoicemeeter: ["long", ["long"]],
 				VBVMR_IsParametersDirty: ["long", []],
+				VBVMR_GetLevel: ["long", ["long", "long", FloatArray]],
 				VBVMR_GetParameterFloat: ["long", [CharArray, FloatArray]],
 				VBVMR_GetParameterStringA: ["long", [CharArray, CharArray]],
 				VBVMR_SetParameters: ["long", [CharArray]],
@@ -337,5 +338,17 @@ export default class Voicemeeter {
 		}
 		const scriptString = `${selector}[${index}].${property}=${value};`;
 		return this.setOption(scriptString);
+	};
+	/**
+	 * Gets realtime audio level see the VoicemeeterRemote API: [VoicemeeterRemote.h GetLevel](https://github.com/mirror/equalizerapo/blob/7aece1b788fce5aa11873f3842a0d01f7c78454b/VoicemeeterClient/VoicemeeterRemote.h#L284),
+	 * for more details about the parameters
+	 * @param {0|1|2|3} type 0 = pre fader input levels. 1 = post fader input levels. 2= post Mute input levels. 3= output levels
+	 * @param channel audio channel zero based index
+	 * @returns {float} Current audio level
+	 */
+	public getLevel = (type: 0 | 1 | 2 | 3, channel: number) => {
+		const levelPtr = new FloatArray(1);
+		libVM.VBVMR_GetLevel(type, channel, levelPtr);
+		return levelPtr[0];
 	};
 }

--- a/src/types/VoicemeeterTypes.ts
+++ b/src/types/VoicemeeterTypes.ts
@@ -5,6 +5,7 @@ export interface VMLibrary {
 	VBVMR_Logout: any;
 	VBVMR_RunVoicemeeter: (voicemeeterType: any) => number;
 	VBVMR_IsParametersDirty: any;
+	VBVMR_GetLevel: any;
 	VBVMR_GetParameterFloat: any;
 	VBVMR_GetParameterStringA: any;
 	VBVMR_SetParameters: any;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds functionality to get real-time audio level data, see: **Real Time Level Meter** in [remote api PDF](https://download.vb-audio.com/Download_CABLE/VoicemeeterRemoteAPI.pdf) and `GetLevel` in [VoicemeeterRemote.h](https://github.com/mirror/equalizerapo/blob/7aece1b788fce5aa11873f3842a0d01f7c78454b/VoicemeeterClient/VoicemeeterRemote.h#L218) for more information about the method


* **What is the current behavior?** (You can also link to an open issue here)
Doesn't exist


* **What is the new behavior (if this is a feature change)?**
Adds a method to get the level data


* **Other information**: