### PR TITLE
Replace ffi-napi with koffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Voicemeeter Connector is a Node.js (Typescript) connector to use the official Vo
 | Package Version | Node Version |
 | --------------- | ------------ |
 | <= 0.62         | 8,10         |
-| >= 1.0          | > 10      |
+| 1.x             | > 10, < 18   |
+| >= 2.0          | >= 18         |
+
+> Node.js now includes build tools for Windows. You probably no longer need this tool. See https://github.com/felixrieseberg/windows-build-tools for details
 
 Execute the following command in a power shell window (Administrator).
 
@@ -53,6 +56,6 @@ Voicemeeter.init().then(async (vm) => {
 
 **Bus** = Outputs (right side of voicemeeter)
 
-## Documetation
+## Documentation
 
 See Documentation on https://chewbaccacookie.github.io/voicemeeter-connector/classes/Voicemeeter.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "voicemeeter-connector",
-	"version": "1.4.1",
+	"version": "1.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "voicemeeter-connector",
-			"version": "1.4.1",
+			"version": "1.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"koffi": "^2.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,14 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "voicemeeter-connector",
 			"version": "1.4.1",
 			"license": "MIT",
 			"dependencies": {
-				"ffi-napi": "4.0.3",
-				"ref-array-napi": "1.2.2",
+				"koffi": "^2.10.1",
 				"winreg": "1.2.4"
 			},
 			"devDependencies": {
-				"@types/ffi-napi": "4.0.5",
 				"@types/node": "17.0.21",
 				"@types/winreg": "1.2.31",
 				"@typescript-eslint/eslint-plugin": "5.13.0",
@@ -25,7 +24,7 @@
 				"eslint-plugin-prettier": "4.0.0",
 				"microbundle": "0.14.2",
 				"prettier": "2.5.1",
-				"typedoc": "0.22.12",
+				"typedoc": "0.22.14",
 				"typescript": "4.6.2"
 			}
 		},
@@ -1839,17 +1838,6 @@
 			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
 			"dev": true
 		},
-		"node_modules/@types/ffi-napi": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@types/ffi-napi/-/ffi-napi-4.0.5.tgz",
-			"integrity": "sha512-WDPpCcHaPhHmP1FIw3ds/+OLt8bYQ/h3SO7o+8kH771PL21kHVzTwii7+WyMBXMQrBsR6xVU2y7w+h+9ggpaQw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"@types/ref-napi": "*",
-				"@types/ref-struct-di": "*"
-			}
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -1873,24 +1861,6 @@
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
-		},
-		"node_modules/@types/ref-napi": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@types/ref-napi/-/ref-napi-1.4.1.tgz",
-			"integrity": "sha512-30A5bpOd+403PJCyyarGH8AOW2IowJ5AZySiGG1B4Sad5CRHt8O+cALEbSUZT+0sE456yAwB2+UjXpH+BIVN1g==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/ref-struct-di": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@types/ref-struct-di/-/ref-struct-di-1.1.0.tgz",
-			"integrity": "sha512-obdtTOGqfV/3MdouZEe2hup7fZwAK6RvusqLIL0hK/MuEBKHWpC3j/NXiC5N6zXdj7p52QB0wsnUEsdkFc+DOw==",
-			"dev": true,
-			"dependencies": {
-				"@types/ref-napi": "*"
-			}
 		},
 		"node_modules/@types/resolve": {
 			"version": "1.17.1",
@@ -2170,31 +2140,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/array-index": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-			"integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
-			"dependencies": {
-				"debug": "^2.2.0",
-				"es6-symbol": "^3.0.2"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/array-index/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/array-index/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -2824,19 +2769,11 @@
 				"node": ">=8.0.0"
 			}
 		},
-		"node_modules/d": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-			"dependencies": {
-				"es5-ext": "^0.10.50",
-				"type": "^1.0.1"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
 			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -3058,40 +2995,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/es5-ext": {
-			"version": "0.10.64",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-			"integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"es6-iterator": "^2.0.3",
-				"es6-symbol": "^3.1.3",
-				"esniff": "^2.0.1",
-				"next-tick": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"dependencies": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"node_modules/es6-symbol": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-			"dependencies": {
-				"d": "^1.0.1",
-				"ext": "^1.1.2"
 			}
 		},
 		"node_modules/escalade": {
@@ -3425,25 +3328,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/esniff": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-			"integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-			"dependencies": {
-				"d": "^1.0.1",
-				"es5-ext": "^0.10.62",
-				"event-emitter": "^0.3.5",
-				"type": "^2.7.2"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/esniff/node_modules/type": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-			"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-		},
 		"node_modules/espree": {
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
@@ -3524,33 +3408,11 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/event-emitter": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-			"dependencies": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
-		},
 		"node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
 			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
 			"dev": true
-		},
-		"node_modules/ext": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-			"integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-			"dependencies": {
-				"type": "^2.0.0"
-			}
-		},
-		"node_modules/ext/node_modules/type": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-			"integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -3611,23 +3473,6 @@
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
-			}
-		},
-		"node_modules/ffi-napi": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
-			"integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-uv-event-loop-napi-h": "^1.0.5",
-				"node-addon-api": "^3.0.0",
-				"node-gyp-build": "^4.2.1",
-				"ref-napi": "^2.0.1 || ^3.0.2",
-				"ref-struct-di": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/figures": {
@@ -3946,19 +3791,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-symbol-from-current-process-h": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-			"integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-		},
-		"node_modules/get-uv-event-loop-napi-h": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-			"integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-			"dependencies": {
-				"get-symbol-from-current-process-h": "^1.0.1"
 			}
 		},
 		"node_modules/glob": {
@@ -4579,6 +4411,13 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/koffi": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.10.1.tgz",
+			"integrity": "sha512-MjsM1/Xi/p4bjl8hThZ35QpuuWu4MurSDBu+diepnqGMNlUOx/m/hisaw25kr7y4g2GG24TLEOCQgHK3BZvfPg==",
+			"hasInstallScript": true,
+			"license": "MIT"
+		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4967,7 +4806,8 @@
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.7",
@@ -4992,26 +4832,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
-		},
-		"node_modules/next-tick": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-		},
-		"node_modules/node-addon-api": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-			"integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
-		},
-		"node_modules/node-gyp-build": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.14",
@@ -5962,66 +5782,6 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
-		"node_modules/ref-array-napi": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/ref-array-napi/-/ref-array-napi-1.2.2.tgz",
-			"integrity": "sha512-EGQzUQpyqD/hN9eIn3uF68UPBmwJXdWkumHCmvK3ncjw128bkjd8TbJ51ur+2PZ4UrfCOQCcPQkuWZ6mNHch9A==",
-			"license": "MIT",
-			"dependencies": {
-				"array-index": "1",
-				"debug": "2",
-				"ref-napi": "^3.0.1"
-			}
-		},
-		"node_modules/ref-array-napi/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/ref-array-napi/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-		},
-		"node_modules/ref-napi": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.2.tgz",
-			"integrity": "sha512-5YE0XrvWteoTr5DR2sEqxefL06aml7c6qS7hGv3u27do4HlGQphwvB+zD1NYep9utMKScvwOZsSs9EPYdGBVsg==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-symbol-from-current-process-h": "^1.0.2",
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.1"
-			},
-			"engines": {
-				"node": ">= 10.0"
-			}
-		},
-		"node_modules/ref-napi/node_modules/node-addon-api": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-		},
-		"node_modules/ref-struct-di": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
-			"integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
-			"dependencies": {
-				"debug": "^3.1.0"
-			}
-		},
-		"node_modules/ref-struct-di/node_modules/debug": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-			"dependencies": {
-				"ms": "^2.1.1"
-			}
-		},
 		"node_modules/regenerate": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -6797,11 +6557,6 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
-		"node_modules/type": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6827,16 +6582,17 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.22.12",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.12.tgz",
-			"integrity": "sha512-FcyC+YuaOpr3rB9QwA1IHOi9KnU2m50sPJW5vcNRPCIdecp+3bFkh7Rq5hBU1Fyn29UR2h4h/H7twZHWDhL0sw==",
+			"version": "0.22.14",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.14.tgz",
+			"integrity": "sha512-tlf9wIcsrnQSjetStrnRutuy2RjZkG5PK2umwveZLTkuC2K9VywOZTdu2G19BdOPzGrhZjf9WK7pthXqnFQejg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^4.0.10",
-				"minimatch": "^3.0.4",
-				"shiki": "^0.10.0"
+				"marked": "^4.0.12",
+				"minimatch": "^5.0.1",
+				"shiki": "^0.10.1"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -6845,7 +6601,30 @@
 				"node": ">= 12.10.0"
 			},
 			"peerDependencies": {
-				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
+				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+			}
+		},
+		"node_modules/typedoc/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/typedoc/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/typescript": {
@@ -8507,17 +8286,6 @@
 			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
 			"dev": true
 		},
-		"@types/ffi-napi": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@types/ffi-napi/-/ffi-napi-4.0.5.tgz",
-			"integrity": "sha512-WDPpCcHaPhHmP1FIw3ds/+OLt8bYQ/h3SO7o+8kH771PL21kHVzTwii7+WyMBXMQrBsR6xVU2y7w+h+9ggpaQw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"@types/ref-napi": "*",
-				"@types/ref-struct-di": "*"
-			}
-		},
 		"@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -8541,24 +8309,6 @@
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
-		},
-		"@types/ref-napi": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@types/ref-napi/-/ref-napi-1.4.1.tgz",
-			"integrity": "sha512-30A5bpOd+403PJCyyarGH8AOW2IowJ5AZySiGG1B4Sad5CRHt8O+cALEbSUZT+0sE456yAwB2+UjXpH+BIVN1g==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/ref-struct-di": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@types/ref-struct-di/-/ref-struct-di-1.1.0.tgz",
-			"integrity": "sha512-obdtTOGqfV/3MdouZEe2hup7fZwAK6RvusqLIL0hK/MuEBKHWpC3j/NXiC5N6zXdj7p52QB0wsnUEsdkFc+DOw==",
-			"dev": true,
-			"requires": {
-				"@types/ref-napi": "*"
-			}
 		},
 		"@types/resolve": {
 			"version": "1.17.1",
@@ -8721,30 +8471,6 @@
 				"es-abstract": "^1.19.1",
 				"get-intrinsic": "^1.1.1",
 				"is-string": "^1.0.7"
-			}
-		},
-		"array-index": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-			"integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
-			"requires": {
-				"debug": "^2.2.0",
-				"es6-symbol": "^3.0.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
 			}
 		},
 		"array-union": {
@@ -9207,19 +8933,11 @@
 				"css-tree": "^1.1.2"
 			}
 		},
-		"d": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-			"requires": {
-				"es5-ext": "^0.10.50",
-				"type": "^1.0.1"
-			}
-		},
 		"debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
 			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -9379,36 +9097,6 @@
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
-			}
-		},
-		"es5-ext": {
-			"version": "0.10.64",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-			"integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-			"requires": {
-				"es6-iterator": "^2.0.3",
-				"es6-symbol": "^3.1.3",
-				"esniff": "^2.0.1",
-				"next-tick": "^1.1.0"
-			}
-		},
-		"es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"es6-symbol": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-			"requires": {
-				"d": "^1.0.1",
-				"ext": "^1.1.2"
 			}
 		},
 		"escalade": {
@@ -9666,24 +9354,6 @@
 			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
 			"dev": true
 		},
-		"esniff": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-			"integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-			"requires": {
-				"d": "^1.0.1",
-				"es5-ext": "^0.10.62",
-				"event-emitter": "^0.3.5",
-				"type": "^2.7.2"
-			},
-			"dependencies": {
-				"type": {
-					"version": "2.7.2",
-					"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-					"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-				}
-			}
-		},
 		"espree": {
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
@@ -9747,35 +9417,11 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
-		"event-emitter": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
-		},
 		"eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
 			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
 			"dev": true
-		},
-		"ext": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-			"integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-			"requires": {
-				"type": "^2.0.0"
-			},
-			"dependencies": {
-				"type": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-					"integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
-				}
-			}
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -9832,19 +9478,6 @@
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
-			}
-		},
-		"ffi-napi": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
-			"integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
-			"requires": {
-				"debug": "^4.1.1",
-				"get-uv-event-loop-napi-h": "^1.0.5",
-				"node-addon-api": "^3.0.0",
-				"node-gyp-build": "^4.2.1",
-				"ref-napi": "^2.0.1 || ^3.0.2",
-				"ref-struct-di": "^1.1.0"
 			}
 		},
 		"figures": {
@@ -10090,19 +9723,6 @@
 			"requires": {
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
-			}
-		},
-		"get-symbol-from-current-process-h": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-			"integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-		},
-		"get-uv-event-loop-napi-h": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-			"integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-			"requires": {
-				"get-symbol-from-current-process-h": "^1.0.1"
 			}
 		},
 		"glob": {
@@ -10553,6 +10173,11 @@
 			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
 			"dev": true
 		},
+		"koffi": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.10.1.tgz",
+			"integrity": "sha512-MjsM1/Xi/p4bjl8hThZ35QpuuWu4MurSDBu+diepnqGMNlUOx/m/hisaw25kr7y4g2GG24TLEOCQgHK3BZvfPg=="
+		},
 		"levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -10869,7 +10494,8 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"nanoid": {
 			"version": "3.3.7",
@@ -10882,21 +10508,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
-		},
-		"next-tick": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-		},
-		"node-addon-api": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-			"integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
-		},
-		"node-gyp-build": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"node-releases": {
 			"version": "2.0.14",
@@ -11512,67 +11123,6 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
-		"ref-array-napi": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/ref-array-napi/-/ref-array-napi-1.2.2.tgz",
-			"integrity": "sha512-EGQzUQpyqD/hN9eIn3uF68UPBmwJXdWkumHCmvK3ncjw128bkjd8TbJ51ur+2PZ4UrfCOQCcPQkuWZ6mNHch9A==",
-			"requires": {
-				"array-index": "1",
-				"debug": "2",
-				"ref-napi": "^3.0.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
-		},
-		"ref-napi": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.2.tgz",
-			"integrity": "sha512-5YE0XrvWteoTr5DR2sEqxefL06aml7c6qS7hGv3u27do4HlGQphwvB+zD1NYep9utMKScvwOZsSs9EPYdGBVsg==",
-			"requires": {
-				"debug": "^4.1.1",
-				"get-symbol-from-current-process-h": "^1.0.2",
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.1"
-			},
-			"dependencies": {
-				"node-addon-api": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-					"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-				}
-			}
-		},
-		"ref-struct-di": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
-			"integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
-			"requires": {
-				"debug": "^3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
 		"regenerate": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -12175,11 +11725,6 @@
 				}
 			}
 		},
-		"type": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-		},
 		"type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -12196,16 +11741,36 @@
 			"dev": true
 		},
 		"typedoc": {
-			"version": "0.22.12",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.12.tgz",
-			"integrity": "sha512-FcyC+YuaOpr3rB9QwA1IHOi9KnU2m50sPJW5vcNRPCIdecp+3bFkh7Rq5hBU1Fyn29UR2h4h/H7twZHWDhL0sw==",
+			"version": "0.22.14",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.14.tgz",
+			"integrity": "sha512-tlf9wIcsrnQSjetStrnRutuy2RjZkG5PK2umwveZLTkuC2K9VywOZTdu2G19BdOPzGrhZjf9WK7pthXqnFQejg==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^4.0.10",
-				"minimatch": "^3.0.4",
-				"shiki": "^0.10.0"
+				"marked": "^4.0.12",
+				"minimatch": "^5.0.1",
+				"shiki": "^0.10.1"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.6",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+					"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				}
 			}
 		},
 		"typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "voicemeeter-connector",
-	"version": "1.5.0",
+	"version": "2.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "voicemeeter-connector",
-			"version": "1.5.0",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"koffi": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "voicemeeter-connector",
-	"version": "1.5.0",
+	"version": "2.0.0",
 	"description": "A Connector to use the Voicemeeter API",
 	"repository": "https://github.com/ChewbaccaCookie/voicemeeter-connector",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "voicemeeter-connector",
-	"version": "1.4.1",
+	"version": "1.5.0",
 	"description": "A Connector to use the Voicemeeter API",
 	"repository": "https://github.com/ChewbaccaCookie/voicemeeter-connector",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,10 @@
 		"generate-docu": "typedoc --out ./docs src/index.ts"
 	},
 	"dependencies": {
-		"ffi-napi": "4.0.3",
-		"ref-array-napi": "1.2.2",
+		"koffi": "^2.10.1",
 		"winreg": "1.2.4"
 	},
 	"devDependencies": {
-		"@types/ffi-napi": "4.0.5",
 		"@types/node": "17.0.21",
 		"@types/winreg": "1.2.31",
 		"@typescript-eslint/eslint-plugin": "5.13.0",
@@ -33,7 +31,7 @@
 		"eslint-plugin-prettier": "4.0.0",
 		"microbundle": "0.14.2",
 		"prettier": "2.5.1",
-		"typedoc": "0.22.12",
+		"typedoc": "0.22.14",
 		"typescript": "4.6.2"
 	},
 	"keywords": [

--- a/src/lib/VoicemeeterConsts.ts
+++ b/src/lib/VoicemeeterConsts.ts
@@ -43,5 +43,5 @@ export enum BusProperties {
 	RepeatMode = "mode.Repeat",
 	CompositeMode = "mode.Composite",
 	FadeTo = "FadeTo",
-	Label = "Label"
+	Label = "Label",
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 		"noImplicitThis": true,
 		"noImplicitAny": true,
 		"strictNullChecks": true,
-		//"suppressImplicitAnyIndexErrors": true,
+		"suppressImplicitAnyIndexErrors": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"skipLibCheck": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 		"noImplicitThis": true,
 		"noImplicitAny": true,
 		"strictNullChecks": true,
-		"suppressImplicitAnyIndexErrors": true,
+		//"suppressImplicitAnyIndexErrors": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"skipLibCheck": true


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix/implementation change, replaces the outdated node-ffi-napi library with https://koffi.dev 


* **What is the current behavior?** (You can also link to an open issue here)
On newer version of node, node-ffi-napi just doesn't really work, see: https://github.com/ChewbaccaCookie/voicemeeter-connector/issues/48


* **What is the new behavior (if this is a feature change)?**
Nothing really changes, just how the voicemeeter remote functions are called and the variables/pointers are handled.


* **Other information**:
I saw on the v2 branch you were restructuring the package, so if any changes are needed related to that let me know so I can change it (or merge my changes on that branch and you do whatever)