### PR TITLE
fix: Cannot connect when app is not running; disconnect crashes process

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,4 +19,11 @@ export default [
             "unicorn/number-literal-case": "off",
         },
     },
+    {
+        languageOptions: {
+            globals: {
+                NodeJS: "readonly"
+            }
+        }
+    }
 ];

--- a/lib/src/lib/voicemeeter-connector.ts
+++ b/lib/src/lib/voicemeeter-connector.ts
@@ -74,46 +74,51 @@ export default class Voicemeeter {
      * Starts a connection to VoiceMeeter
      */
     public connect = (): { success: boolean; message: string; code: number } | never => {
-    if (!this.isInitialised) {
-        throw new Error("Await the initialisation before connect");
-    }
-    if (this.isConnected) {
-        // If already connected, still return success status instead of throwing
-        return { success: true, message: "Already connected.", code: 0 }; 
-    }
+        if (!this.isInitialised) {
+            throw new Error("Await the initialisation before connect");
+        }
+        if (this.isConnected) {
+            // If already connected, still return success status instead of throwing
+            return { success: true, message: "Already connected.", code: 0 };
+        }
 
-    const loginResult = libVM.VBVMR_Login();
-    
-    switch (loginResult) {
-        case 0:
-            // Complete success, Voicemeeter is running
-            this.isConnected = true;
-            this.type = this.getVoicemeeterType(); 
-            this.version = this.getVoicemeeterVersion(); 
-            this.timerInterval = setInterval(this.checkPropertyChange, 10); 
-            return { success: true, message: "Successfully connected to VoiceMeeter (VM Running).", code: 0 };
-        case 1:
-            // Connected successfully but Voicemeeter application is not running
-            // Pipe is established, can wait for VM to start
-            this.isConnected = true; 
-            this.type = undefined; 
-            this.version = "Unknown";  
-            this.timerInterval = setInterval(this.checkPropertyChange, 10); 
-            return { success: true, message: "Connected to VoiceMeeter API (VM App Not Running).", code: 1 };
-        case -1:
-            // Failed to get client (unexpected error) - throw error
-            this.isConnected = false;
-            throw new Error(`VoiceMeeter connection failed: Unable to get client (Unexpected error -1).`);
-        case -2:
-            // Unexpected login (logout should have been executed first) - throw error
-            this.isConnected = false;
-            throw new Error(`VoiceMeeter connection failed: Unexpected login (Expected logout first -2).`);
-        default:
-            // Unknown return value - throw error
-            this.isConnected = false;
-            throw new Error(`VoiceMeeter connection failed with unknown error code: ${loginResult}.`);
-    }
-};
+        const loginResult = libVM.VBVMR_Login();
+
+        switch (loginResult) {
+            case 0: {
+                // Complete success, Voicemeeter is running
+                this.isConnected = true;
+                this.type = this.getVoicemeeterType();
+                this.version = this.getVoicemeeterVersion();
+                this.timerInterval = setInterval(this.checkPropertyChange, 10);
+                return { success: true, message: "Successfully connected to VoiceMeeter (VM Running).", code: 0 };
+            }
+            case 1: {
+                // Connected successfully but Voicemeeter application is not running
+                // Pipe is established, can wait for VM to start
+                this.isConnected = true;
+                this.type = undefined;
+                this.version = "Unknown";
+                this.timerInterval = setInterval(this.checkPropertyChange, 10);
+                return { success: true, message: "Connected to VoiceMeeter API (VM App Not Running).", code: 1 };
+            }
+            case -1: {
+                // Failed to get client (unexpected error) - throw error
+                this.isConnected = false;
+                throw new Error("VoiceMeeter connection failed: Unable to get client (Unexpected error -1).");
+            }
+            case -2: {
+                // Unexpected login (logout should have been executed first) - throw error
+                this.isConnected = false;
+                throw new Error("VoiceMeeter connection failed: Unexpected login (Expected logout first -2).");
+            }
+            default: {
+                // Unknown return value - throw error
+                this.isConnected = false;
+                throw new Error(`VoiceMeeter connection failed with unknown error code: ${loginResult}.`);
+            }
+        }
+    };
 
     /**
      * Getter $outputDevices


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
  + When Voicemeeter is not running, the connection fails. Subsequent launches of Voicemeeter still cannot establish a connection unless the Node.js program is restarted.
  + The disconnect() method triggers a fatal crash in the Node.js process.
- **What is the new behavior (if this is a feature change)?**
  + For connection handling:
   Return status codes when establishing connections to enable proper caller-side handling, while maintaining backward compatibility with existing error throwing behavior.
  + For disconnection:
   Clear setInterval when calling disconnect.

- **Other information**:
N/A