### PR TITLE
feat: Added audio callback methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,29 @@ Refresh the list of available input and output devices.
 vm.updateDeviceList();
 ```
 
+### VB-Audio Callback
+
+Register an audio callback, start/stop and unregister.
+
+```typescript
+vm.registerAudioCallback(AudioCallbackModes.MAIN, "Your client name", someAudioCallbackFunction);
+await vm.startAudioCallback();
+await vm.stopAudioCallback();
+await vm.unregisterAudioCallback();
+```
+
+**AudioCallbackModes enum values:**
+
+- `INPUT` (0x00000001): Voicemeeter Input Insert 
+- `OUTPUT` (0x00000002): Voicemeeter Output Insert
+- `MAIN` (0x00000004): Voicemeeter Main
+
+**Audio Callback Examples:**
+
+- **TypeScript:** [`examples/typescript/example-audiocallback.ts`](examples/typescript/example-audiocallback.ts)
+- **ESM JavaScript:** [`examples/javascript-module/example-audiocallback.js`](examples/javascript-module/example-audiocallback.js)
+- **CommonJS JavaScript:** [`examples/javascript-commonjs/example-audiocallback.js`](examples/javascript-commonjs/example-audiocallback.js)
+
 ### Disconnecting
 
 Gracefully disconnects from the Voicemeeter client.

--- a/examples/javascript-commonjs/example-audiocallback.js
+++ b/examples/javascript-commonjs/example-audiocallback.js
@@ -171,7 +171,7 @@ void Voicemeeter.init().then(async (vm) => {
 
     // Output recorded audio signal to first bus
     let playbackPosition = 0;
-    const playAudioFile = (event) => {
+    const playRecordedAudio = (event) => {
         if (event.command === AudioCallbackCommands.STARTING) {
             playbackPosition = 0;
         }
@@ -216,7 +216,7 @@ void Voicemeeter.init().then(async (vm) => {
     await tryAudioCallback(AudioCallbackModes.OUTPUT, "Output recorder", audioCallbackFactory(recordOutputChannel));
 
     console.log("==== Playing recorded audio ====");
-    await tryAudioCallback(AudioCallbackModes.OUTPUT, "Audio playbacker", audioCallbackFactory(playAudioFile));
+    await tryAudioCallback(AudioCallbackModes.OUTPUT, "Audio playbacker", audioCallbackFactory(playRecordedAudio));
 
     console.log("Disconnecting voicemeeter.");
     vm.disconnect();

--- a/examples/javascript-commonjs/example-audiocallback.js
+++ b/examples/javascript-commonjs/example-audiocallback.js
@@ -1,0 +1,223 @@
+/* eslint-disable unicorn/prefer-top-level-await */
+// eslint-disable-next-line @typescript-eslint/no-require-imports, unicorn/prefer-module
+const { AudioCallbackCommands, AudioCallbackModes, Voicemeeter } = require("voicemeeter-connector");
+
+void Voicemeeter.init().then(async (vm) => {
+    // Connect to your voicemeeter client
+    vm.connect();
+
+    // Simple factory function which handles shared errors and some logging for start/stop events
+    const audioCallbackFactory = (callback) => {
+        return (error, event) => {
+            if (error !== null) {
+                console.error(error, event === undefined ? undefined : JSON.stringify(event));
+                return;
+            }
+            if (event === undefined) {
+                console.error("[CALLBACK] Audio callback received no event data.");
+                return;
+            }
+            // Logs the info events
+            if (event.command === AudioCallbackCommands.STARTING) {
+                console.log("[CALLBACK] Callback has started.");
+            }
+            if (event.command === AudioCallbackCommands.CHANGE) {
+                console.log("[CALLBACK] Change in audio stream.");
+            }
+            if (event.command === AudioCallbackCommands.ENDING) {
+                console.log("[CALLBACK] Callback has stopped.");
+            }
+            // Call the defined callback
+            callback(event);
+        };
+    };
+
+    const sleep = (ms) => {
+        return new Promise((resolve) => {
+            setTimeout(resolve, ms);
+        });
+    };
+
+    /* 
+        Utility function that just tries out an audio callback for 10s. Can be for several modes
+    */
+    const tryAudioCallback = async (mode, clientName, callback) => {
+        const modes = Array.isArray(mode) ? mode : [mode];
+        for (const callbackMode of modes) {
+            vm.registerAudioCallback(callbackMode, clientName, callback);
+        }
+        console.log("Starting audio callback...");
+        await vm.startAudioCallback();
+
+        await sleep(10_000);
+        // Stopping the audio callback is done automatically when unregistering a callback, so this isn't really necessary.
+        console.log("Stopping audio callback...");
+        await vm.stopAudioCallback();
+
+        const unregisterPromises = [];
+        for (const callbackMode of modes) {
+            unregisterPromises.push(vm.unregisterAudioCallback(callbackMode));
+        }
+        await Promise.all(unregisterPromises);
+    };
+
+    /*
+        Since the VB-Audio Callback system lets you process/change the audio signal, there are a lot of possible use cases.
+        Below are some very basic callback examples, some other examples not implemented here are:
+        - Analysing the audio, for example: performing an FFT to get the frequency spectrum, 
+        - Monitor the audio level in real-time, instead of relying on .getLevel()
+        - Audio effects, gates, fades, noise filter
+        - etc... 
+    
+        Additionally it's important to be aware of the channel assignment and how many physical/virtual strips each voicemeeter version has.
+        e.g. Voicemeeter (the base version) has 12 channels (see the inputChannelCountMap property on the vm instance), where the first 4 channels are physical,
+        and channels 4-11 are virtual.
+        If you'd want to mute all physical strips, you need to know how many physical strips each version has to get the channel range.
+        See the audio callback section in VoicemeeterRemoteAPI.pdf, or the section above VBVMR_AudioCallbackRegister in VoicemeeterRemote.h
+        on the SDK github: https://github.com/vburel2018/Voicemeeter-SDK
+    
+        Each audio stream (BUFFER_IN, BUFFER_OUT and BUFFER_MAIN) can only be registered once. Possibly from 3 different applications.
+    */
+
+    // ===================== Start of callback examples =====================
+
+    // Mutes the output of any callback
+    const simpleFullMute = () => {
+        // Since outputSignal isn't assigned any values here, it'll just contain zeroes and the output signal will be silent
+    };
+
+    // Mute specific channels, here just the first physical strip and the first bus
+    const MUTE_STRIP_CHANNELS = new Set([0, 1]);
+    const MUTE_BUS_CHANNELS = new Set([0, 1, 2, 3, 4, 5, 6, 7]);
+
+    const muteSpecificChannels = (event) => {
+        // BUFFER_IN for the strips
+        if (event.command === AudioCallbackCommands.BUFFER_IN) {
+            const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+            for (const [ch, inputChannel] of inputChannels.entries()) {
+                // Don't copy audio signal if it should be muted
+                if (MUTE_STRIP_CHANNELS.has(ch)) {
+                    continue;
+                }
+                for (let i = 0; i < samplesPerFrame; i++) {
+                    outputChannels[ch][i] = inputChannel[i];
+                }
+            }
+        }
+
+        // BUFFER_OUT for the buses
+        if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+            const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+            for (const [ch, inputChannel] of inputChannels.entries()) {
+                // Don't copy audio signal if it should be muted
+                if (MUTE_BUS_CHANNELS.has(ch)) {
+                    continue;
+                }
+                for (let i = 0; i < samplesPerFrame; i++) {
+                    outputChannels[ch][i] = inputChannel[i];
+                }
+            }
+        }
+    };
+
+    // Swaps the channels of the first 2 output devices
+    const swapTwoOutputDevices = (event) => {
+        if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+            const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+            // Takes the first 8 input channels, and copies the signal to the output channels 8-15
+            for (const [ch, inputChannel] of inputChannels.slice(0, 8).entries()) {
+                const outputChannel = outputChannels[ch + 8];
+                for (let i = 0; i < samplesPerFrame; i++) {
+                    outputChannel[i] = inputChannel[i];
+                }
+            }
+            // Takes the input channels 8-15, and copies them to the output channels 0-7
+            for (const [ch, inputChannel] of inputChannels.slice(8, 16).entries()) {
+                const outputChannel = outputChannels[ch];
+                for (let i = 0; i < samplesPerFrame; i++) {
+                    outputChannel[i] = inputChannel[i];
+                }
+            }
+        }
+    };
+
+    // Record audio signal of the first bus
+    const recordedSamples = Array.from({ length: 8 }, () => []);
+
+    const recordOutputChannel = (event) => {
+        if (event.command === AudioCallbackCommands.STARTING) {
+            console.log("Recording started");
+        }
+        if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+            const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+            // Store the samples of the first 8 channels, and passthrough the signal
+            for (const [ch, inputChannel] of inputChannels.slice(0, 8).entries()) {
+                for (let i = 0; i < samplesPerFrame; i++) {
+                    recordedSamples[ch].push(inputChannel[i]);
+                    outputChannels[ch][i] = inputChannel[i];
+                }
+            }
+            // Directly passthrough audio signal
+            for (const [ch, inputChannel] of inputChannels.slice(8).entries()) {
+                for (let i = 0; i < samplesPerFrame; i++) {
+                    outputChannels[ch + 8][i] = inputChannel[i];
+                }
+            }
+        }
+        if (event.command === AudioCallbackCommands.ENDING) {
+            console.log("Recording finished. Total samples:", recordedSamples[0].length);
+        }
+    };
+
+    // Output recorded audio signal to first bus
+    let playbackPosition = 0;
+    const playAudioFile = (event) => {
+        if (event.command === AudioCallbackCommands.STARTING) {
+            playbackPosition = 0;
+        }
+
+        if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+            const { samplesPerFrame, outputChannels, inputChannels } = event.data;
+
+            for (const [ch, inputChannel] of inputChannels.slice(0, 8).entries()) {
+                for (let i = 0; i < samplesPerFrame; i++) {
+                    const sampleIndex = playbackPosition + i;
+                    const recordedSample = sampleIndex < recordedSamples[ch].length ? recordedSamples[ch][sampleIndex] : 0;
+                    // Clamp the value to avoid clipping
+                    const mixedSample = Math.max(-1, Math.min(1, inputChannel[i] + recordedSample));
+                    outputChannels[ch][i] = mixedSample;
+                }
+            }
+            // Directly passthrough audio signal
+            for (const [ch, inputChannel] of inputChannels.slice(8).entries()) {
+                for (let i = 0; i < samplesPerFrame; i++) {
+                    outputChannels[ch + 8][i] = inputChannel[i];
+                }
+            }
+            playbackPosition += samplesPerFrame;
+        }
+    };
+
+    console.log("==== Muting all audio ====");
+    await tryAudioCallback(AudioCallbackModes.MAIN, "Audio muter", audioCallbackFactory(simpleFullMute));
+
+    // Here the same callback is used for BUFFER_IN and BUFFER_OUT
+    console.log("==== Muting specific audio channels ====");
+    await tryAudioCallback(
+        [AudioCallbackModes.INPUT, AudioCallbackModes.OUTPUT],
+        "Channel muter",
+        audioCallbackFactory(muteSpecificChannels)
+    );
+
+    console.log("==== Swapping output device channels ====");
+    await tryAudioCallback(AudioCallbackModes.OUTPUT, "Device swapper", audioCallbackFactory(swapTwoOutputDevices));
+
+    console.log("==== Recording audio from first bus ====");
+    await tryAudioCallback(AudioCallbackModes.OUTPUT, "Output recorder", audioCallbackFactory(recordOutputChannel));
+
+    console.log("==== Playing recorded audio ====");
+    await tryAudioCallback(AudioCallbackModes.OUTPUT, "Audio playbacker", audioCallbackFactory(playAudioFile));
+
+    console.log("Disconnecting voicemeeter.");
+    vm.disconnect();
+});

--- a/examples/javascript-commonjs/example.js
+++ b/examples/javascript-commonjs/example.js
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/prefer-top-level-await */
 // eslint-disable-next-line @typescript-eslint/no-require-imports, unicorn/prefer-module
-const { Voicemeeter, StripProperties, MacroButtonModes } = require("voicemeeter-connector");
+const { AudioCallbackCommands, AudioCallbackModes, MacroButtonModes, StripProperties, Voicemeeter } = require("voicemeeter-connector");
 
 void Voicemeeter.init().then(async (vm) => {
     // Connect to your voicemeeter client
@@ -33,9 +33,58 @@ void Voicemeeter.init().then(async (vm) => {
     // get MacroButton state
     console.log(vm.getMacroButtonStatus(0, MacroButtonModes.DEFAULT));
 
-    // Disconnect voicemeeter client
-    setTimeout(() => {
+    /* 
+        Basic VB-Audio Callback example
+        more advanced examples in the example-audiocallback.js file
+    */
+
+    // Index at which the first bus output starts in inputChannels (for the MAIN stream)
+    const offset = vm.$type === undefined ? 0 : Voicemeeter.inputChannelCountMap[vm.$type];
+
+    /*  
+        This callback just passes through the output channels after output INSERT (in inputChannels), to the output channels.
+        To passthrough output to output, it would be better to use BUFFER_OUT here, since you don't need the strip signal. Allowing another application to use BUFFER_MAIN
+    */
+    const simplePassthroughCallback = (error, event) => {
+        // Handle errors
+        if (error !== null) {
+            console.error(error, event === undefined ? undefined : JSON.stringify(event));
+            return;
+        }
+        if (event === undefined) {
+            console.error("Event data undefined.");
+            return;
+        }
+
+        if (event.command === AudioCallbackCommands.BUFFER_MAIN) {
+            const { outputChannels, inputChannels, samplesPerFrame } = event.data;
+            for (const [ch, outputChannel] of outputChannels.entries()) {
+                for (let i = 0; i < samplesPerFrame; i++) {
+                    outputChannel[i] = inputChannels[offset + ch][i];
+                }
+            }
+        }
+    };
+
+    // Register the audio callback
+    vm.registerAudioCallback(AudioCallbackModes.MAIN, "Cool client name", simplePassthroughCallback);
+    console.log("Registered audio callback.");
+
+    // Start the audio callback
+    await vm.startAudioCallback().catch((error) => {
+        console.error(error);
+    });
+    console.log("Started audio callback.");
+
+    // Explicitly unregister and disconnect voicemeeter client
+    setTimeout(async () => {
+        await vm.unregisterAudioCallback(AudioCallbackModes.MAIN).catch((error) => {
+            console.error(error);
+        });
+        console.log("Unregistered audio callback.");
+
         vm.disconnect();
+        console.log("Disconnected voicemeeter.");
         process.exit(0);
-    }, 5000);
+    }, 20_000);
 });

--- a/examples/javascript-commonjs/package.json
+++ b/examples/javascript-commonjs/package.json
@@ -5,7 +5,8 @@
 	"description": "Example how to use the Voicemeeter Connector library in CommonJS project.",
 	"main": "example.js",
 	"scripts": {
-		"start": "node example.js"
+		"start": "node example.js",
+		"start:callback": "node example-audiocallback.js"
 	},
 	"dependencies": {}
 }

--- a/examples/javascript-module/example-audiocallback.js
+++ b/examples/javascript-module/example-audiocallback.js
@@ -1,0 +1,217 @@
+import { AudioCallbackCommands, AudioCallbackModes, Voicemeeter } from "voicemeeter-connector";
+
+const vm = await Voicemeeter.init();
+
+// Connect to your voicemeeter client
+vm.connect();
+
+// Simple factory function which handles shared errors and some logging for start/stop events
+const audioCallbackFactory = (callback) => {
+    return (error, event) => {
+        if (error !== null) {
+            console.error(error, event === undefined ? undefined : JSON.stringify(event));
+            return;
+        }
+        if (event === undefined) {
+            console.error("[CALLBACK] Audio callback received no event data.");
+            return;
+        }
+        // Logs the info events
+        if (event.command === AudioCallbackCommands.STARTING) {
+            console.log("[CALLBACK] Callback has started.");
+        }
+        if (event.command === AudioCallbackCommands.CHANGE) {
+            console.log("[CALLBACK] Change in audio stream.");
+        }
+        if (event.command === AudioCallbackCommands.ENDING) {
+            console.log("[CALLBACK] Callback has stopped.");
+        }
+        // Call the defined callback
+        callback(event);
+    };
+};
+
+const sleep = (ms) => {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+};
+
+/* 
+    Utility function that just tries out an audio callback for 10s. Can be for several modes
+*/
+const tryAudioCallback = async (mode, clientName, callback) => {
+    const modes = Array.isArray(mode) ? mode : [mode];
+    for (const callbackMode of modes) {
+        vm.registerAudioCallback(callbackMode, clientName, callback);
+    }
+    console.log("Starting audio callback...");
+    await vm.startAudioCallback();
+
+    await sleep(10_000);
+    // Stopping the audio callback is done automatically when unregistering a callback, so this isn't really necessary.
+    console.log("Stopping audio callback...");
+    await vm.stopAudioCallback();
+
+    const unregisterPromises = [];
+    for (const callbackMode of modes) {
+        unregisterPromises.push(vm.unregisterAudioCallback(callbackMode));
+    }
+    await Promise.all(unregisterPromises);
+};
+
+/*
+    Since the VB-Audio Callback system lets you process/change the audio signal, there are a lot of possible use cases.
+    Below are some very basic callback examples, some other examples not implemented here are:
+    - Analysing the audio, for example: performing an FFT to get the frequency spectrum, 
+    - Monitor the audio level in real-time, instead of relying on .getLevel()
+    - Audio effects, gates, fades, noise filter
+    - etc... 
+ 
+    Additionally it's important to be aware of the channel assignment and how many physical/virtual strips each voicemeeter version has.
+    e.g. Voicemeeter (the base version) has 12 channels (see the inputChannelCountMap property on the vm instance), where the first 4 channels are physical,
+    and channels 4-11 are virtual.
+    If you'd want to mute all physical strips, you need to know how many physical strips each version has to get the channel range.
+    See the audio callback section in VoicemeeterRemoteAPI.pdf, or the section above VBVMR_AudioCallbackRegister in VoicemeeterRemote.h
+    on the SDK github: https://github.com/vburel2018/Voicemeeter-SDK
+ 
+    Each audio stream (BUFFER_IN, BUFFER_OUT and BUFFER_MAIN) can only be registered once. Possibly from 3 different applications.
+*/
+
+// ===================== Start of callback examples =====================
+
+// Mutes the output of any callback
+const simpleFullMute = () => {
+    // Since outputSignal isn't assigned any values here, it'll just contain zeroes and the output signal will be silent
+};
+
+// Mute specific channels, here just the first physical strip and the first bus
+const MUTE_STRIP_CHANNELS = new Set([0, 1]);
+const MUTE_BUS_CHANNELS = new Set([0, 1, 2, 3, 4, 5, 6, 7]);
+
+const muteSpecificChannels = (event) => {
+    // BUFFER_IN for the strips
+    if (event.command === AudioCallbackCommands.BUFFER_IN) {
+        const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+        for (const [ch, inputChannel] of inputChannels.entries()) {
+            // Don't copy audio signal if it should be muted
+            if (MUTE_STRIP_CHANNELS.has(ch)) {
+                continue;
+            }
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannels[ch][i] = inputChannel[i];
+            }
+        }
+    }
+
+    // BUFFER_OUT for the buses
+    if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+        const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+        for (const [ch, inputChannel] of inputChannels.entries()) {
+            // Don't copy audio signal if it should be muted
+            if (MUTE_BUS_CHANNELS.has(ch)) {
+                continue;
+            }
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannels[ch][i] = inputChannel[i];
+            }
+        }
+    }
+};
+
+// Swaps the channels of the first 2 output devices
+const swapTwoOutputDevices = (event) => {
+    if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+        const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+        // Takes the first 8 input channels, and copies the signal to the output channels 8-15
+        for (const [ch, inputChannel] of inputChannels.slice(0, 8).entries()) {
+            const outputChannel = outputChannels[ch + 8];
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannel[i] = inputChannel[i];
+            }
+        }
+        // Takes the input channels 8-15, and copies them to the output channels 0-7
+        for (const [ch, inputChannel] of inputChannels.slice(8, 16).entries()) {
+            const outputChannel = outputChannels[ch];
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannel[i] = inputChannel[i];
+            }
+        }
+    }
+};
+
+// Record audio signal of the first bus
+const recordedSamples = Array.from({ length: 8 }, () => []);
+
+const recordOutputChannel = (event) => {
+    if (event.command === AudioCallbackCommands.STARTING) {
+        console.log("Recording started");
+    }
+    if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+        const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+        // Store the samples of the first 8 channels, and passthrough the signal
+        for (const [ch, inputChannel] of inputChannels.slice(0, 8).entries()) {
+            for (let i = 0; i < samplesPerFrame; i++) {
+                recordedSamples[ch].push(inputChannel[i]);
+                outputChannels[ch][i] = inputChannel[i];
+            }
+        }
+        // Directly passthrough audio signal
+        for (const [ch, inputChannel] of inputChannels.slice(8).entries()) {
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannels[ch + 8][i] = inputChannel[i];
+            }
+        }
+    }
+    if (event.command === AudioCallbackCommands.ENDING) {
+        console.log("Recording finished. Total samples:", recordedSamples[0].length);
+    }
+};
+
+// Output recorded audio signal to first bus
+let playbackPosition = 0;
+const playAudioFile = (event) => {
+    if (event.command === AudioCallbackCommands.STARTING) {
+        playbackPosition = 0;
+    }
+
+    if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+        const { samplesPerFrame, outputChannels, inputChannels } = event.data;
+
+        for (const [ch, inputChannel] of inputChannels.slice(0, 8).entries()) {
+            for (let i = 0; i < samplesPerFrame; i++) {
+                const sampleIndex = playbackPosition + i;
+                const recordedSample = sampleIndex < recordedSamples[ch].length ? recordedSamples[ch][sampleIndex] : 0;
+                // Clamp the value to avoid clipping
+                const mixedSample = Math.max(-1, Math.min(1, inputChannel[i] + recordedSample));
+                outputChannels[ch][i] = mixedSample;
+            }
+        }
+        // Directly passthrough audio signal
+        for (const [ch, inputChannel] of inputChannels.slice(8).entries()) {
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannels[ch + 8][i] = inputChannel[i];
+            }
+        }
+        playbackPosition += samplesPerFrame;
+    }
+};
+
+console.log("==== Muting all audio ====");
+await tryAudioCallback(AudioCallbackModes.MAIN, "Audio muter", audioCallbackFactory(simpleFullMute));
+
+// Here the same callback is used for BUFFER_IN and BUFFER_OUT
+console.log("==== Muting specific audio channels ====");
+await tryAudioCallback([AudioCallbackModes.INPUT, AudioCallbackModes.OUTPUT], "Channel muter", audioCallbackFactory(muteSpecificChannels));
+
+console.log("==== Swapping output device channels ====");
+await tryAudioCallback(AudioCallbackModes.OUTPUT, "Device swapper", audioCallbackFactory(swapTwoOutputDevices));
+
+console.log("==== Recording audio from first bus ====");
+await tryAudioCallback(AudioCallbackModes.OUTPUT, "Output recorder", audioCallbackFactory(recordOutputChannel));
+
+console.log("==== Playing recorded audio ====");
+await tryAudioCallback(AudioCallbackModes.OUTPUT, "Audio playbacker", audioCallbackFactory(playAudioFile));
+
+console.log("Disconnecting voicemeeter.");
+vm.disconnect();

--- a/examples/javascript-module/example-audiocallback.js
+++ b/examples/javascript-module/example-audiocallback.js
@@ -170,7 +170,7 @@ const recordOutputChannel = (event) => {
 
 // Output recorded audio signal to first bus
 let playbackPosition = 0;
-const playAudioFile = (event) => {
+const playRecordedAudio = (event) => {
     if (event.command === AudioCallbackCommands.STARTING) {
         playbackPosition = 0;
     }
@@ -211,7 +211,7 @@ console.log("==== Recording audio from first bus ====");
 await tryAudioCallback(AudioCallbackModes.OUTPUT, "Output recorder", audioCallbackFactory(recordOutputChannel));
 
 console.log("==== Playing recorded audio ====");
-await tryAudioCallback(AudioCallbackModes.OUTPUT, "Audio playbacker", audioCallbackFactory(playAudioFile));
+await tryAudioCallback(AudioCallbackModes.OUTPUT, "Audio playbacker", audioCallbackFactory(playRecordedAudio));
 
 console.log("Disconnecting voicemeeter.");
 vm.disconnect();

--- a/examples/javascript-module/example.js
+++ b/examples/javascript-module/example.js
@@ -1,4 +1,4 @@
-import { MacroButtonModes, StripProperties, Voicemeeter } from "voicemeeter-connector";
+import { AudioCallbackCommands, AudioCallbackModes, MacroButtonModes, StripProperties, Voicemeeter } from "voicemeeter-connector";
 
 const vm = await Voicemeeter.init();
 
@@ -32,8 +32,57 @@ console.log(vm.setMacroButtonStatus(0, 1, MacroButtonModes.DEFAULT));
 // get MacroButton state
 console.log(vm.getMacroButtonStatus(0, MacroButtonModes.DEFAULT));
 
-// Disconnect voicemeeter client
-setTimeout(() => {
+/* 
+    Basic VB-Audio Callback example
+    more advanced examples in the example-audiocallback.js file
+*/
+
+// Index at which the first bus output starts in inputChannels (for the MAIN stream)
+const offset = vm.$type === undefined ? 0 : Voicemeeter.inputChannelCountMap[vm.$type];
+
+/*  
+    This callback just passes through the output channels after output INSERT (in inputChannels), to the output channels.
+    To passthrough output to output, it would be better to use BUFFER_OUT here, since you don't need the strip signal. Allowing another application to use BUFFER_MAIN
+*/
+const simplePassthroughCallback = (error, event) => {
+    // Handle errors
+    if (error !== null) {
+        console.error(error, event === undefined ? undefined : JSON.stringify(event));
+        return;
+    }
+    if (event === undefined) {
+        console.error("Event data undefined.");
+        return;
+    }
+
+    if (event.command === AudioCallbackCommands.BUFFER_MAIN) {
+        const { outputChannels, inputChannels, samplesPerFrame } = event.data;
+        for (const [ch, outputChannel] of outputChannels.entries()) {
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannel[i] = inputChannels[offset + ch][i];
+            }
+        }
+    }
+};
+
+// Register the audio callback
+vm.registerAudioCallback(AudioCallbackModes.MAIN, "Cool client name", simplePassthroughCallback);
+console.log("Registered audio callback.");
+
+// Start the audio callback
+await vm.startAudioCallback().catch((error) => {
+    console.error(error);
+});
+console.log("Started audio callback.");
+
+// Explicitly unregister and disconnect voicemeeter client
+setTimeout(async () => {
+    await vm.unregisterAudioCallback(AudioCallbackModes.MAIN).catch((error) => {
+        console.error(error);
+    });
+    console.log("Unregistered audio callback.");
+
     vm.disconnect();
+    console.log("Disconnected voicemeeter.");
     process.exit(0);
-}, 5000);
+}, 20_000);

--- a/examples/javascript-module/package.json
+++ b/examples/javascript-module/package.json
@@ -5,7 +5,8 @@
 	"description": "Examples how to use the Voicemeeter Connector library in a JavaScript module project.",
 	"main": "example.js",
 	"scripts": {
-		"start": "node example.js"
+		"start": "node example.js",
+		"start:callback": "node example-audiocallback.js"
 	},
 	"dependencies": {}
 }

--- a/examples/typescript/example-audiocallback.ts
+++ b/examples/typescript/example-audiocallback.ts
@@ -1,0 +1,218 @@
+import { AudioCallbackCommands, AudioCallbackModes, types, Voicemeeter } from "voicemeeter-connector";
+import { AudioCallbackEvent } from "voicemeeter-connector/dist/types/voicemeeter-types";
+
+const vm = await Voicemeeter.init();
+
+// Connect to your voicemeeter client
+vm.connect();
+
+// Simple factory function which handles shared errors and some logging for start/stop events
+const audioCallbackFactory = (callback: (event: types.AudioCallbackEvent) => void): types.AudioCallbackFunction => {
+    return (error: Error | null, event?: types.AudioCallbackEvent) => {
+        if (error !== null) {
+            console.error(error, event === undefined ? undefined : JSON.stringify(event));
+            return;
+        }
+        if (event === undefined) {
+            console.error("[CALLBACK] Audio callback received no event data.");
+            return;
+        }
+        // Logs the info events
+        if (event.command === AudioCallbackCommands.STARTING) {
+            console.log("[CALLBACK] Callback has started.");
+        }
+        if (event.command === AudioCallbackCommands.CHANGE) {
+            console.log("[CALLBACK] Change in audio stream.");
+        }
+        if (event.command === AudioCallbackCommands.ENDING) {
+            console.log("[CALLBACK] Callback has stopped.");
+        }
+        // Call the defined callback
+        callback(event);
+    };
+};
+
+const sleep = (ms: number): Promise<void> => {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+};
+
+/* 
+    Utility function that just tries out an audio callback for 10s. Can be for several modes
+*/
+type Mode = 1 | 2 | 4;
+
+const tryAudioCallback = async (mode: Mode | Array<Mode>, clientName: string, callback: types.AudioCallbackFunction) => {
+    const modes = Array.isArray(mode) ? mode : [mode];
+    for (const callbackMode of modes) {
+        vm.registerAudioCallback(callbackMode, clientName, callback);
+    }
+    console.log("Starting audio callback...");
+    await vm.startAudioCallback();
+
+    await sleep(10_000);
+    // Stopping the audio callback is done automatically when unregistering a callback, so this isn't really necessary.
+    console.log("Stopping audio callback...");
+    await vm.stopAudioCallback();
+
+    const unregisterPromises = [];
+    for (const callbackMode of modes) {
+        unregisterPromises.push(vm.unregisterAudioCallback(callbackMode));
+    }
+    await Promise.all(unregisterPromises);
+};
+
+/*
+    Since the VB-Audio Callback system lets you process/change the audio signal, there are a lot of possible use cases.
+    Below are some very basic callback examples, some other examples not implemented here are:
+    - Analysing the audio, for example: performing an FFT to get the frequency spectrum, 
+    - Monitor the audio level in real-time, instead of relying on .getLevel()
+    - Audio effects, gates, fades, noise filter
+    - etc... 
+
+    Additionally it's important to be aware of the channel assignment and how many physical/virtual strips each voicemeeter version has.
+    e.g. Voicemeeter (the base version) has 12 channels (see the inputChannelCountMap property on the vm instance), where the first 4 channels are physical,
+    and channels 4-11 are virtual.
+    If you'd want to mute all physical strips, you need to know how many physical strips each version has to get the channel range.
+    See the audio callback section in VoicemeeterRemoteAPI.pdf, or the section above VBVMR_AudioCallbackRegister in VoicemeeterRemote.h
+    on the SDK github: https://github.com/vburel2018/Voicemeeter-SDK
+
+    Each audio stream (BUFFER_IN, BUFFER_OUT and BUFFER_MAIN) can only be registered once. Possibly from 3 different applications.
+*/
+
+// Mutes the output of any callback
+const simpleFullMute = (): void => {
+    // Since outputSignal isn't assigned any values here, it'll just contain zeroes and the output signal will be silent
+};
+
+// Mute specific channels, here just the first physical strip and the first bus
+const MUTE_STRIP_CHANNELS = new Set([0, 1]);
+const MUTE_BUS_CHANNELS = new Set([0, 1, 2, 3, 4, 5, 6, 7]);
+
+const muteSpecificChannels = (event: AudioCallbackEvent) => {
+    // BUFFER_IN for the strips
+    if (event.command === AudioCallbackCommands.BUFFER_IN) {
+        const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+        for (const [ch, inputChannel] of inputChannels.entries()) {
+            // Don't copy audio signal if it should be muted
+            if (MUTE_STRIP_CHANNELS.has(ch)) {
+                continue;
+            }
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannels[ch][i] = inputChannel[i];
+            }
+        }
+    }
+
+    // BUFFER_OUT for the buses
+    if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+        const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+        for (const [ch, inputChannel] of inputChannels.entries()) {
+            // Don't copy audio signal if it should be muted
+            if (MUTE_BUS_CHANNELS.has(ch)) {
+                continue;
+            }
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannels[ch][i] = inputChannel[i];
+            }
+        }
+    }
+};
+
+// Swaps the channels of the first 2 output devices
+const swapTwoOutputDevices = (event: types.AudioCallbackEvent): void => {
+    if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+        const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+        // Takes the first 8 input channels, and copies the signal to the output channels 8-15
+        for (const [ch, inputChannel] of inputChannels.slice(0, 8).entries()) {
+            const outputChannel = outputChannels[ch + 8];
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannel[i] = inputChannel[i];
+            }
+        }
+        // Takes the input channels 8-15, and copies them to the output channels 0-7
+        for (const [ch, inputChannel] of inputChannels.slice(8, 16).entries()) {
+            const outputChannel = outputChannels[ch];
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannel[i] = inputChannel[i];
+            }
+        }
+    }
+};
+
+// Record audio signal of the first bus
+const recordedSamples: Array<number[]> = Array.from({ length: 8 }, () => []);
+
+const recordOutputChannel = (event: types.AudioCallbackEvent) => {
+    if (event.command === AudioCallbackCommands.STARTING) {
+        console.log("Recording started");
+    }
+    if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+        const { inputChannels, samplesPerFrame, outputChannels } = event.data;
+        // Store the samples of the first 8 channels, and passthrough the signal
+        for (const [ch, inputChannel] of inputChannels.slice(0, 8).entries()) {
+            for (let i = 0; i < samplesPerFrame; i++) {
+                recordedSamples[ch].push(inputChannel[i]);
+                outputChannels[ch][i] = inputChannel[i];
+            }
+        }
+        // Directly passthrough audio signal
+        for (const [ch, inputChannel] of inputChannels.slice(8).entries()) {
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannels[ch + 8][i] = inputChannel[i];
+            }
+        }
+    }
+    if (event.command === AudioCallbackCommands.ENDING) {
+        console.log("Recording finished. Total samples:", recordedSamples[0].length);
+    }
+};
+
+// Output recorded audio signal to first bus
+let playbackPosition = 0;
+const playAudioFile = (event: types.AudioCallbackEvent) => {
+    if (event.command === AudioCallbackCommands.STARTING) {
+        playbackPosition = 0;
+    }
+
+    if (event.command === AudioCallbackCommands.BUFFER_OUT) {
+        const { samplesPerFrame, outputChannels, inputChannels } = event.data;
+
+        for (const [ch, inputChannel] of inputChannels.slice(0, 8).entries()) {
+            for (let i = 0; i < samplesPerFrame; i++) {
+                const sampleIndex = playbackPosition + i;
+                const recordedSample = sampleIndex < recordedSamples[ch].length ? recordedSamples[ch][sampleIndex] : 0;
+                // Clamp the value to avoid clipping
+                const mixedSample = Math.max(-1, Math.min(1, inputChannel[i] + recordedSample));
+                outputChannels[ch][i] = mixedSample;
+            }
+        }
+        // Directly passthrough audio signal
+        for (const [ch, inputChannel] of inputChannels.slice(8).entries()) {
+            for (let i = 0; i < samplesPerFrame; i++) {
+                outputChannels[ch + 8][i] = inputChannel[i];
+            }
+        }
+        playbackPosition += samplesPerFrame;
+    }
+};
+
+console.log("==== Muting all audio ====");
+await tryAudioCallback(AudioCallbackModes.MAIN, "Audio muter", audioCallbackFactory(simpleFullMute));
+
+// Here the same callback is used for BUFFER_IN and BUFFER_OUT
+console.log("==== Muting specific audio channels ====");
+await tryAudioCallback([AudioCallbackModes.INPUT, AudioCallbackModes.OUTPUT], "Channel muter", audioCallbackFactory(muteSpecificChannels));
+
+console.log("==== Swapping output device channels ====");
+await tryAudioCallback(AudioCallbackModes.OUTPUT, "Device swapper", audioCallbackFactory(swapTwoOutputDevices));
+
+console.log("==== Recording audio from first bus ====");
+await tryAudioCallback(AudioCallbackModes.OUTPUT, "Output recorder", audioCallbackFactory(recordOutputChannel));
+
+console.log("==== Playing recorded audio ====");
+await tryAudioCallback(AudioCallbackModes.OUTPUT, "Audio playbacker", audioCallbackFactory(playAudioFile));
+
+console.log("Disconnecting voicemeeter.");
+vm.disconnect();

--- a/examples/typescript/example-audiocallback.ts
+++ b/examples/typescript/example-audiocallback.ts
@@ -171,7 +171,7 @@ const recordOutputChannel = (event: types.AudioCallbackEvent) => {
 
 // Output recorded audio signal to first bus
 let playbackPosition = 0;
-const playAudioFile = (event: types.AudioCallbackEvent) => {
+const playRecordedAudio = (event: types.AudioCallbackEvent) => {
     if (event.command === AudioCallbackCommands.STARTING) {
         playbackPosition = 0;
     }
@@ -212,7 +212,7 @@ console.log("==== Recording audio from first bus ====");
 await tryAudioCallback(AudioCallbackModes.OUTPUT, "Output recorder", audioCallbackFactory(recordOutputChannel));
 
 console.log("==== Playing recorded audio ====");
-await tryAudioCallback(AudioCallbackModes.OUTPUT, "Audio playbacker", audioCallbackFactory(playAudioFile));
+await tryAudioCallback(AudioCallbackModes.OUTPUT, "Audio playbacker", audioCallbackFactory(playRecordedAudio));
 
 console.log("Disconnecting voicemeeter.");
 vm.disconnect();

--- a/examples/typescript/example.ts
+++ b/examples/typescript/example.ts
@@ -35,8 +35,28 @@ vm.attachChangeEvent(() => {
     console.log("Something changed!");
 });
 
+vm.registerAudioCallback(
+    4,
+    (arg) => {
+        if (arg.command === "starting") {
+            console.log(`Started audio callback with sampleRate: ${arg.data.sampleRate}`);
+        }
+        if (arg.command === "ending") {
+            console.log("Stopped audio callback");
+        }
+    },
+    "ConnectorApp"
+);
+
+vm.startAudioCallback();
+
+setTimeout(() => {
+    vm.unregisterAudioCallback();
+    console.log("Unregistering audio callback");
+}, 5000);
+
 // Disconnect voicemeeter client
 setTimeout(() => {
     vm.disconnect();
     process.exit(0);
-}, 5000);
+}, 20_000);

--- a/examples/typescript/example.ts
+++ b/examples/typescript/example.ts
@@ -54,12 +54,12 @@ switch (vm.$type) {
         break;
     }
 }
+
 // This callback just passes through the audio signal to the output channels, without any changes
 const simplePassthroughCallback = (arg: types.AudioCallbackArg) => {
     if (arg.command === AudioCallbackCommands.BUFFER_MAIN) {
         const { outputChannels, inputChannels, samplesPerFrame } = arg.data;
         for (const [ch, outputChannel] of outputChannels.entries()) {
-            console.log(outputChannel[0]);
             for (let i = 0; i < samplesPerFrame; i++) {
                 outputChannel[i] = inputChannels[inputOffset + ch][i];
             }
@@ -72,8 +72,12 @@ const simplePassthroughCallback = (arg: types.AudioCallbackArg) => {
         console.log("Stopped audio callback");
     }
 };
+
 // Register the audio callback
-vm.registerAudioCallback(AudioCallbackModes.MAIN, simplePassthroughCallback, "ConnectorApp");
+vm.registerAudioCallback(AudioCallbackModes.MAIN, simplePassthroughCallback, "ConnectorApp", undefined, (error, arg) => {
+    // Log any error that occured in the callback
+    console.error(error, arg === undefined ? "With arg not defined" : `With arg ${arg}`);
+});
 
 // Start the audio callback
 vm.startAudioCallback();

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,9 +5,9 @@
 	"description": "Examples how to use the Voicemeeter Connector library in a TypeScript module project.",
 	"main": "example.js",
 	"scripts": {
-		"start": "npx tsx example.ts"
+		"start": "npx tsx example.ts",
+		"start:callback": "npx tsx example-audiocallback.ts"
 	},
-	"dependencies": {},
 	"devDependencies": {
 		"tsx": "^4.20.3",
 		"typescript": "^5.8.3"

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -8,6 +8,7 @@
 		"start": "npx tsx example.ts",
 		"start:callback": "npx tsx example-audiocallback.ts"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"tsx": "^4.20.3",
 		"typescript": "^5.8.3"

--- a/lib/package.json
+++ b/lib/package.json
@@ -13,7 +13,7 @@
 		"dev": "microbundle watch"
 	},
 	"dependencies": {
-		"koffi": "2.12.1",
+		"koffi": "2.13.0",
 		"winreg": "1.2.5"
 	},
 	"devDependencies": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "voicemeeter-connector",
-	"version": "2.1.5",
+	"version": "2.2.0",
 	"description": "A Connector to use the Voicemeeter API",
 	"repository": "https://github.com/ChewbaccaCookie/voicemeeter-connector",
 	"license": "MIT",

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,8 +1,8 @@
 import * as constants from "./lib/constants";
 
-const { BusProperties, InterfaceTypes, StripProperties, MacroButtonModes } = constants;
+const { BusProperties, InterfaceTypes, StripProperties, MacroButtonModes, AudioCallbackModes, AudioCallbackCommands } = constants;
 
-export { BusProperties, InterfaceTypes, MacroButtonModes, StripProperties };
+export { AudioCallbackCommands, AudioCallbackModes, BusProperties, InterfaceTypes, MacroButtonModes, StripProperties };
 
 export { default as Voicemeeter } from "./lib/voicemeeter-connector";
 export * as types from "./types/voicemeeter-types";

--- a/lib/src/lib/constants.ts
+++ b/lib/src/lib/constants.ts
@@ -55,15 +55,6 @@ export enum MacroButtonModes {
     COLOR = 0x00_00_00_04,
 }
 
-export const audioCallbackCommandMap = {
-    1: "starting",
-    2: "ending",
-    3: "change",
-    10: "buffer_in",
-    11: "buffer_out",
-    20: "buffer_main",
-} as const;
-
 export enum AudioCallbackModes {
     INPUT = 1,
     OUTPUT = 2,

--- a/lib/src/lib/constants.ts
+++ b/lib/src/lib/constants.ts
@@ -56,8 +56,8 @@ export enum MacroButtonModes {
 }
 
 export const InitialAudioCallbackState = {
-    pointer: undefined,
-    pendingUnregister: false,
+    pointer: null,
+    awaitUnregister: [],
     ended: true,
 };
 

--- a/lib/src/lib/constants.ts
+++ b/lib/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import koffi from "koffi";
+
 export const InterfaceTypes = {
     strip: 0,
     bus: 1,
@@ -52,3 +54,41 @@ export enum MacroButtonModes {
     TRIGGER = 0x00_00_00_03,
     COLOR = 0x00_00_00_04,
 }
+
+export const audioCallbackCommandMap = {
+    1: "starting",
+    2: "ending",
+    3: "change",
+    10: "buffer_in",
+    11: "buffer_out",
+    20: "buffer_main",
+} as const;
+
+export enum AudioCallbackModes {
+    INPUT = 1,
+    OUTPUT = 2,
+    MAIN = 4,
+}
+
+export enum AudioCallbackCommands {
+    STARTING = 1,
+    ENDING = 2,
+    CHANGE = 3,
+    BUFFER_IN = 10,
+    BUFFER_OUT = 11,
+    BUFFER_MAIN = 20,
+}
+
+export const AudioInfoStruct = koffi.struct("VBVMR_T_AUDIOINFO", {
+    samplerate: "long",
+    nbSamplePerFrame: "long",
+});
+
+export const AudioBufferStruct = koffi.struct("VBVMR_T_AUDIOBUFFER", {
+    audiobuffer_sr: "long",
+    audiobuffer_nbs: "long",
+    audiobuffer_nbi: "long",
+    audiobuffer_nbo: "long",
+    audiobuffer_r: koffi.array("float*", 128),
+    audiobuffer_w: koffi.array("float*", 128),
+});

--- a/lib/src/lib/constants.ts
+++ b/lib/src/lib/constants.ts
@@ -55,6 +55,12 @@ export enum MacroButtonModes {
     COLOR = 0x00_00_00_04,
 }
 
+export const InitialAudioCallbackState = {
+    pointer: undefined,
+    pendingUnregister: false,
+    ended: true,
+};
+
 export enum AudioCallbackModes {
     INPUT = 1,
     OUTPUT = 2,

--- a/lib/src/lib/voicemeeter-connector.ts
+++ b/lib/src/lib/voicemeeter-connector.ts
@@ -2,8 +2,9 @@
 import koffi from "koffi";
 
 import {
-    AudioCallbackArg,
     AudioCallbackBuffer,
+    AudioCallbackEvent,
+    AudioCallbackFunction,
     AudioCallbackInfo,
     AudioCallbackState,
     Device,
@@ -28,6 +29,10 @@ import DLLHandler from "./dll-handler";
  * @ignore
  */
 let libVM: VMLibrary;
+/**
+ * @ignore
+ */
+let audioCallbackProtoPointer: koffi.IKoffiCType;
 /**
  * @ignore
  */
@@ -81,6 +86,10 @@ export default class Voicemeeter {
                 VBVMR_AudioCallbackUnregister: lib.func("long __stdcall VBVMR_AudioCallbackUnregister(void* audioCallback)"),
             };
 
+            audioCallbackProtoPointer = koffi.pointer(
+                koffi.proto("long __stdcall AudioCallback(void* lpUser, long nCommand, void* lpData, long nnn)")
+            );
+
             instance.isInitialised = true;
             resolve(instance);
         });
@@ -96,9 +105,13 @@ export default class Voicemeeter {
     private stringParameters = ["Label", "FadeTo", "FadeBy", "AppGain", "AppMute", "name", "ip"];
     private timerInterval: NodeJS.Timeout;
     private audioCallbackStates: Record<AudioCallbackModes, AudioCallbackState> = {
-        [AudioCallbackModes.MAIN]: InitialAudioCallbackState,
-        [AudioCallbackModes.INPUT]: InitialAudioCallbackState,
-        [AudioCallbackModes.OUTPUT]: InitialAudioCallbackState,
+        [AudioCallbackModes.MAIN]: { ...InitialAudioCallbackState },
+        [AudioCallbackModes.INPUT]: { ...InitialAudioCallbackState },
+        [AudioCallbackModes.OUTPUT]: { ...InitialAudioCallbackState },
+    };
+    private awaitAudioCallbackEvents: { start: Array<() => void>; stop: Array<() => void> } = {
+        start: [],
+        stop: [],
     };
 
     /**
@@ -191,6 +204,7 @@ export default class Voicemeeter {
             throw new Error("Not connected ");
         }
         try {
+            this.unregisterAllAudioCallbacks().catch(() => {});
             if (libVM.VBVMR_Logout() === 0) {
                 clearInterval(this.timerInterval);
                 this.isConnected = false;
@@ -364,46 +378,90 @@ export default class Voicemeeter {
         }
     };
 
+    /**
+     * The amount of input channels per voicemeeter version
+     */
+    public static inputChannelCountMap: Record<Exclude<VoiceMeeterTypes, undefined>, number> = {
+        voicemeeter: 12,
+        voicemeeterBanana: 22,
+        voicemeeterPotato: 34,
+    };
+
+    /**
+     * The amount of output channels per voicemeeter version
+     */
+    public static outputChannelCountMap: Record<Exclude<VoiceMeeterTypes, undefined>, number> = {
+        voicemeeter: 16,
+        voicemeeterBanana: 40,
+        voicemeeterPotato: 64,
+    };
+
+    /**
+     * Registers an audio callback function to process/change real time audio stream data from Voicemeeter.
+     * @description For more detailed info about the audio callback system, see the Voicemeeter Remote API pdf and VoicemeeterRemote.h on https://github.com/vburel2018/Voicemeeter-SDK
+     * @param {AudioCallbackModes} mode - The audio callback type. See {@link AudioCallbackModes}
+     * @param {string} clientName - Name of the application registering the callback (max 64 ASCII chars)
+     * @param {AudioCallbackFunction} callback - Function called for each audio stream event.
+     * The first argument is an Error if one occurs, otherwise null. The second argument provides the decoded audio event.
+     * @param {Object} [config] - Optional configuration object.
+     * @param {Buffer} [config.lpUser] - Optional user context pointer passed to the callback.
+     * @param {boolean} [config.restartOnChangedStream=true] - If true, automatically restarts the callback when the audio stream changes. Defaults to true
+     * @throws {Error} Throws an error if the callback is already registered, or if registration fails.
+     */
     public registerAudioCallback = (
         mode: AudioCallbackModes,
-        callback: (arg: AudioCallbackArg) => void,
         clientName: string,
-        lpUser?: Buffer,
-        errorCallback?: (err: unknown, arg?: AudioCallbackArg) => void
+        callback: AudioCallbackFunction,
+        config?: {
+            lpUser?: Buffer;
+            restartOnChangedStream?: boolean;
+        }
     ): void => {
-        if (this.audioCallbackStates[mode].pointer !== undefined) {
+        if (this.audioCallbackStates[mode].pointer !== null) {
             throw new Error(`Audio callback for "${mode}" is already registered.`);
         }
 
         this.audioCallbackStates[mode].pointer = koffi.register(
             (lpUser: Buffer, nCommand: number, lpData: unknown, nnn: number): number => {
-                let audioCallbackArg: AudioCallbackArg | undefined;
+                let audioCallbackEvent: AudioCallbackEvent | undefined;
 
                 try {
                     switch (nCommand) {
                         case AudioCallbackCommands.STARTING: {
                             this.audioCallbackStates[mode].ended = false;
-                            audioCallbackArg = { lpUser, nnn, command: nCommand, data: this.convertToAudioCallbackInfo(lpData) };
+                            audioCallbackEvent = { lpUser, nnn, command: nCommand, data: this.convertToAudioCallbackInfo(lpData) };
+                            this.resolveAudioCallbackEvent("start");
                             break;
                         }
                         case AudioCallbackCommands.ENDING: {
                             this.audioCallbackStates[mode].ended = true;
-                            audioCallbackArg = { lpUser, nnn, command: nCommand, data: this.convertToAudioCallbackInfo(lpData) };
+                            audioCallbackEvent = { lpUser, nnn, command: nCommand, data: this.convertToAudioCallbackInfo(lpData) };
+                            this.resolveAudioCallbackEvent("stop");
                             break;
                         }
                         case AudioCallbackCommands.CHANGE: {
-                            audioCallbackArg = { lpUser, nnn, command: nCommand, data: this.convertToAudioCallbackInfo(lpData) };
+                            audioCallbackEvent = { lpUser, nnn, command: nCommand, data: this.convertToAudioCallbackInfo(lpData) };
                             /*
                                 CHANGE occurs when the main audio stream, sample rate or buffer size has changed.
-                                restart stream after a few ms 
+                                the audio callback is stopped by voicemeeter when this happens,
+                                See: https://github.com/vburel2018/Voicemeeter-SDK/blob/3be2c1c36563afbd6df3da8436406c77d2cc1f10/example0/vmr_client.c#L718
+                                This is just an exact copy of the implentation there.
                             */
-                            setTimeout(() => this.startAudioCallback(), 50);
+                            if (config?.restartOnChangedStream ?? true) {
+                                setTimeout(() => {
+                                    this.startAudioCallback().catch((unknownError) => {
+                                        const error = this.convertToErrorObject(unknownError);
+                                        error.message = "Failed to restart callback after changed stream: " + error.message;
+                                        callback(error, audioCallbackEvent);
+                                    });
+                                }, 50);
+                            }
                             break;
                         }
                         case AudioCallbackCommands.BUFFER_IN:
                         case AudioCallbackCommands.BUFFER_OUT:
                         case AudioCallbackCommands.BUFFER_MAIN: {
-                            audioCallbackArg = { lpUser, nnn, command: nCommand, data: this.convertToAudioCallbackBuffer(lpData) };
+                            audioCallbackEvent = { lpUser, nnn, command: nCommand, data: this.convertToAudioCallbackBuffer(lpData) };
                             break;
                         }
                         default: {
@@ -411,39 +469,41 @@ export default class Voicemeeter {
                         }
                     }
 
-                    try {
-                        callback(audioCallbackArg);
-                    } catch (error: unknown) {
-                        if (errorCallback !== undefined) {
-                            errorCallback(error, audioCallbackArg);
-                        }
-                    }
-
+                    // If the stream has stopped, check if any unregisters are scheduled to resolve their promises
                     if (
                         nCommand === AudioCallbackCommands.ENDING &&
-                        this.audioCallbackStates[mode].pendingUnregister &&
-                        this.audioCallbackStates[mode].pointer !== undefined
+                        this.audioCallbackStates[mode].awaitUnregister.length > 0 &&
+                        this.audioCallbackStates[mode].pointer !== null
                     ) {
                         koffi.unregister(this.audioCallbackStates[mode].pointer);
-                        delete this.audioCallbackStates[mode].pointer;
-                        this.audioCallbackStates[mode].pendingUnregister = false;
+                        this.audioCallbackStates[mode].pointer = null;
+                        while (this.audioCallbackStates[mode].awaitUnregister.length > 0) {
+                            const resolve = this.audioCallbackStates[mode].awaitUnregister.shift();
+                            if (resolve !== undefined) {
+                                resolve();
+                            }
+                        }
                     }
-                } catch (error: unknown) {
-                    // Library error
-                    if (errorCallback !== undefined) {
-                        errorCallback(error, audioCallbackArg);
-                    }
+                } catch (unknownError: unknown) {
+                    const error = this.convertToErrorObject(unknownError);
+                    callback(error, audioCallbackEvent);
+                    return 0;
                 }
+                callback(null, audioCallbackEvent);
                 return 0;
             },
-            koffi.pointer(koffi.proto("long __stdcall AudioCallback(void* lpUser, long nCommand, void* lpData, long nnn)"))
+            audioCallbackProtoPointer
         );
 
         const clientNamePtr = Buffer.alloc(64);
         clientNamePtr.write(clientName);
 
-        const result = libVM.VBVMR_AudioCallbackRegister(mode, this.audioCallbackStates[mode].pointer, lpUser ?? null, clientNamePtr);
-        const outClientName = clientNamePtr.toString().replace("/\u0000+$/g", "");
+        const result = libVM.VBVMR_AudioCallbackRegister(
+            mode,
+            this.audioCallbackStates[mode].pointer,
+            config?.lpUser ?? null,
+            clientNamePtr
+        );
 
         switch (result) {
             case 0: {
@@ -452,7 +512,9 @@ export default class Voicemeeter {
             case -1: {
                 throw new Error("Failed to register audio callback");
             }
+            // VoicemeeterRemote.h says this case should have result = 1, but in reality this appears to be -2
             case -2: {
+                const outClientName = clientNamePtr.toString().replace("/\u0000+$/g", "");
                 throw new Error(`Audio callback already registered by: ${outClientName}`);
             }
             default: {
@@ -461,72 +523,144 @@ export default class Voicemeeter {
         }
     };
 
-    public startAudioCallback = (): void => {
-        const result = libVM.VBVMR_AudioCallbackStart();
-        switch (result) {
-            case 0: {
+    /**
+     * Starts the audio stream to the audio callback.
+     * @returns {Promise<void>} Resolves when started, rejects with Error if failed.
+     */
+    public startAudioCallback = (): Promise<void> => {
+        return new Promise((resolve, reject) => {
+            const result = libVM.VBVMR_AudioCallbackStart();
+            if (result === 0) {
+                this.awaitAudioCallbackEvents.start.push(() => resolve());
                 return;
             }
-            case -1: {
-                throw new Error("Failed to start audio callback");
-            }
-            case -2: {
-                throw new Error("No audio callback registered");
-            }
-            default: {
-                throw new Error(`Unexpected result starting audio callback ${result}`);
-            }
-        }
-    };
 
-    public stopAudioCallback = (): void => {
-        const result = libVM.VBVMR_AudioCallbackStop();
-        switch (result) {
-            case 0: {
-                return;
-            }
-            case -1: {
-                throw new Error("Failed to stop audio callback");
-            }
-            case -2: {
-                throw new Error("No audio callback registered");
-            }
-            default: {
-                throw new Error(`Unexpected result stopping audio callback: ${result}`);
-            }
-        }
-    };
-
-    public unregisterAudioCallback = (mode: AudioCallbackModes): void => {
-        if (this.audioCallbackStates[mode].pointer === undefined) {
-            throw new Error(`No audio callback registered for "${mode}" in library`);
-        }
-
-        const result = libVM.VBVMR_AudioCallbackUnregister(this.audioCallbackStates[mode].pointer);
-        switch (result) {
-            case 0: {
-                // It is not safe to unregister when the callback hasn't been stopped, wait for ENDING first
-                if (this.audioCallbackStates[mode].ended) {
-                    koffi.unregister(this.audioCallbackStates[mode].pointer);
-                    delete this.audioCallbackStates[mode].pointer;
-                } else {
-                    this.audioCallbackStates[mode].pendingUnregister = true;
+            let errorReason: string;
+            switch (result) {
+                case -1: {
+                    errorReason = "Failed to start audio callback";
+                    break;
                 }
-                return;
+                case -2: {
+                    errorReason = "No audio callback registered";
+                    break;
+                }
+                default: {
+                    errorReason = `Unexpected result starting audio callback ${result}`;
+                }
             }
-            case -1: {
-                throw new Error("Failed to unregister audio callback");
-            }
-            case -2: {
-                delete this.audioCallbackStates[mode].pointer;
-                throw new Error("Callback already unregistered");
-            }
-            default: {
-                throw new Error(`Unexpected result unregistering audio callback ${result}`);
-            }
-        }
+            reject(new Error(errorReason));
+        });
     };
 
+    /**
+     * Stops the audio stream to the audio callback.
+     * @returns {Promise<void>} Resolves when stopped, rejects with Error if failed.
+     */
+    public stopAudioCallback = (): Promise<void> => {
+        return new Promise((resolve, reject) => {
+            const result = libVM.VBVMR_AudioCallbackStop();
+            if (result === 0) {
+                this.awaitAudioCallbackEvents.stop.push(() => resolve());
+                return;
+            }
+
+            let errorReason: string;
+            switch (result) {
+                case -1: {
+                    errorReason = "Failed to stop audio callback";
+                    break;
+                }
+                case -2: {
+                    errorReason = "No audio callback registered";
+                    break;
+                }
+                default: {
+                    errorReason = `Unexpected result stopping audio callback: ${result}`;
+                    break;
+                }
+            }
+            reject(errorReason);
+        });
+    };
+
+    /**
+     * Unregisters the audio callback.
+     * @description Internally voicemeeter automatically calls stopAudioCallback(), so it's not strictly necessary to stop and then unregister.
+     * @param {AudioCallbackModes} mode - The audio callback type. See {@link AudioCallbackModes}
+     * @returns {Promise<void>} Resolves when unregistered, rejects with Error if failed.
+     */
+    public unregisterAudioCallback = (mode: AudioCallbackModes): Promise<void> => {
+        return new Promise((resolve, reject) => {
+            if (this.audioCallbackStates[mode].pointer === null) {
+                reject(new Error(`No audio callback registered for "${mode}"`));
+                return;
+            }
+
+            const result = libVM.VBVMR_AudioCallbackUnregister(this.audioCallbackStates[mode].pointer);
+            switch (result) {
+                case 0: {
+                    // It is not safe to unregister when the callback hasn't ended, wait for ENDING first
+                    if (this.audioCallbackStates[mode].ended) {
+                        koffi.unregister(this.audioCallbackStates[mode].pointer);
+                        this.audioCallbackStates[mode].pointer = null;
+                        resolve();
+                    } else {
+                        // Wait for ENDING first
+                        this.audioCallbackStates[mode].awaitUnregister.push(() => resolve());
+                    }
+                    return;
+                }
+                case -1: {
+                    reject(new Error("Failed to unregister audio callback"));
+                    break;
+                }
+                case -2: {
+                    // -2 means the callback has already been unregistered, this case shouldn't occur
+                    this.audioCallbackStates[mode].pointer = null;
+                    resolve();
+                    break;
+                }
+                default: {
+                    reject(new Error(`Unexpected result unregistering audio callback ${result}`));
+                }
+            }
+        });
+    };
+
+    /**
+     * Unregisters all registered audio callbacks.
+     * @returns {Promise<void[]>} Resolves when all callbacks are unregistered.
+     */
+    public unregisterAllAudioCallbacks = (): Promise<void[]> => {
+        const promises: Array<Promise<void>> = [];
+        for (const [mode, state] of Object.entries(this.audioCallbackStates)) {
+            if (state.pointer === null) {
+                continue;
+            }
+            promises.push(this.unregisterAudioCallback(<AudioCallbackModes>(<unknown>mode)));
+        }
+        return Promise.all(promises);
+    };
+
+    /**
+     * Resolves all pending promises for a given audio callback event type.
+     * @param {"start"|"stop"} type - The event type to resolve ('start' or 'stop').
+     */
+    private resolveAudioCallbackEvent(type: "start" | "stop"): void {
+        while (this.awaitAudioCallbackEvents[type].length > 0) {
+            const resolve = this.awaitAudioCallbackEvents[type].shift();
+            if (resolve !== undefined) {
+                resolve();
+            }
+        }
+    }
+
+    /**
+     * Converts raw callback data to an AudioCallbackInfo object.
+     * @param {unknown} lpData - Raw data pointer from Voicemeeter.
+     * @returns {AudioCallbackInfo} Decoded audio callback info.
+     */
     private convertToAudioCallbackInfo = (lpData: unknown): AudioCallbackInfo => {
         const rawData = koffi.decode(lpData, AudioInfoStruct) as VBVMR_T_AUDIOINFO;
         return {
@@ -535,6 +669,11 @@ export default class Voicemeeter {
         };
     };
 
+    /**
+     * Converts raw callback data to an AudioCallbackBuffer object.
+     * @param {unknown} lpData - Raw data pointer from Voicemeeter.
+     * @returns {AudioCallbackBuffer} Decoded audio buffer data.
+     */
     private convertToAudioCallbackBuffer = (lpData: unknown): AudioCallbackBuffer => {
         const rawData = koffi.decode(lpData, AudioBufferStruct) as VBVMR_T_AUDIOBUFFER;
         const data: AudioCallbackBuffer = {
@@ -553,6 +692,21 @@ export default class Voicemeeter {
             data.outputChannels.push(new Float32Array(koffi.view(rawData.audiobuffer_w[i], rawData.audiobuffer_nbs * 4)));
         }
         return data;
+    };
+
+    /**
+     * Converts an unknown error value to an Error object.
+     * @param {unknown} unknownError - An unknown error value.
+     * @returns {Error} Converted Error object.
+     */
+    private convertToErrorObject = (unknownError: unknown): Error => {
+        if (unknownError instanceof Error) {
+            return unknownError;
+        }
+        if (typeof unknownError === "string") {
+            return new Error(unknownError);
+        }
+        return new Error(`Unknown error: ${String(unknownError)}`);
     };
 
     /**

--- a/lib/src/types/voicemeeter-types.ts
+++ b/lib/src/types/voicemeeter-types.ts
@@ -34,6 +34,8 @@ export interface Device {
     type: number;
 }
 
+export type AudioCallbackFunction = (error: Error | null, event?: AudioCallbackEvent) => void;
+
 export interface VBVMR_T_AUDIOINFO {
     samplerate: number;
     nbSamplePerFrame: number;
@@ -54,8 +56,8 @@ export interface VBVMR_T_AUDIOBUFFER {
 }
 
 export interface AudioCallbackState {
-    pointer: IKoffiRegisteredCallback | undefined;
-    pendingUnregister: boolean;
+    pointer: IKoffiRegisteredCallback | null;
+    awaitUnregister: Array<() => void>;
     ended: boolean;
 }
 
@@ -68,19 +70,19 @@ export interface AudioCallbackBuffer {
     outputChannels: Float32Array[];
 }
 
-export interface BaseAudioCallbackArg {
+export interface BaseAudioCallbackEvent {
     lpUser: Buffer | null;
     nnn: number;
 }
 
-export interface AudioCallbackInfoArg extends BaseAudioCallbackArg {
+export interface AudioCallbackInfoEvent extends BaseAudioCallbackEvent {
     command: AudioCallbackCommands.STARTING | AudioCallbackCommands.CHANGE | AudioCallbackCommands.ENDING;
     data: AudioCallbackInfo;
 }
 
-export interface AudioCallbackBufferArg extends BaseAudioCallbackArg {
+export interface AudioCallbackBufferEvent extends BaseAudioCallbackEvent {
     command: AudioCallbackCommands.BUFFER_IN | AudioCallbackCommands.BUFFER_OUT | AudioCallbackCommands.BUFFER_MAIN;
     data: AudioCallbackBuffer;
 }
 
-export type AudioCallbackArg = AudioCallbackInfoArg | AudioCallbackBufferArg;
+export type AudioCallbackEvent = AudioCallbackInfoEvent | AudioCallbackBufferEvent;

--- a/lib/src/types/voicemeeter-types.ts
+++ b/lib/src/types/voicemeeter-types.ts
@@ -1,3 +1,5 @@
+import { AudioCallbackCommands } from "../lib/constants";
+
 export type VoiceMeeterTypes = "voicemeeter" | "voicemeeterBanana" | "voicemeeterPotato" | undefined;
 
 export interface VMLibrary {
@@ -30,18 +32,32 @@ export interface Device {
     type: number;
 }
 
+export interface VBVMR_T_AUDIOINFO {
+    samplerate: number;
+    nbSamplePerFrame: number;
+}
+
 export interface AudioCallbackInfo {
     sampleRate: number;
     samplesPerFrame: number;
 }
 
+export interface VBVMR_T_AUDIOBUFFER {
+    audiobuffer_sr: number;
+    audiobuffer_nbs: number;
+    audiobuffer_nbi: number;
+    audiobuffer_nbo: number;
+    audiobuffer_r: Float32Array[];
+    audiobuffer_w: Float32Array[];
+}
+
 export interface AudioCallbackBuffer {
     sampleRate: number;
     samplesPerFrame: number;
-    numInputs: number;
-    numOutputs: number;
-    inputs: Float32Array[];
-    outputs: Float32Array[];
+    inputChannelCount: number;
+    outputChannelCount: number;
+    inputChannels: Float32Array[];
+    outputChannels: Float32Array[];
 }
 
 export interface BaseAudioCallbackArg {
@@ -50,12 +66,12 @@ export interface BaseAudioCallbackArg {
 }
 
 export interface AudioCallbackInfoArg extends BaseAudioCallbackArg {
-    command: "starting" | "change" | "ending";
+    command: AudioCallbackCommands.STARTING | AudioCallbackCommands.CHANGE | AudioCallbackCommands.ENDING;
     data: AudioCallbackInfo;
 }
 
 export interface AudioCallbackBufferArg extends BaseAudioCallbackArg {
-    command: "buffer_in" | "buffer_out" | "buffer_main";
+    command: AudioCallbackCommands.BUFFER_IN | AudioCallbackCommands.BUFFER_OUT | AudioCallbackCommands.BUFFER_MAIN;
     data: AudioCallbackBuffer;
 }
 

--- a/lib/src/types/voicemeeter-types.ts
+++ b/lib/src/types/voicemeeter-types.ts
@@ -18,6 +18,10 @@ export interface VMLibrary {
     VBVMR_MacroButton_IsDirty: any;
     VBVMR_MacroButton_GetStatus: any;
     VBVMR_MacroButton_SetStatus: any;
+    VBVMR_AudioCallbackRegister: any;
+    VBVMR_AudioCallbackStart: any;
+    VBVMR_AudioCallbackStop: any;
+    VBVMR_AudioCallbackUnregister: any;
 }
 
 export interface Device {
@@ -25,3 +29,34 @@ export interface Device {
     hardwareId: string;
     type: number;
 }
+
+export interface AudioCallbackInfo {
+    sampleRate: number;
+    samplesPerFrame: number;
+}
+
+export interface AudioCallbackBuffer {
+    sampleRate: number;
+    samplesPerFrame: number;
+    numInputs: number;
+    numOutputs: number;
+    inputs: Float32Array[];
+    outputs: Float32Array[];
+}
+
+export interface BaseAudioCallbackArg {
+    lpUser: Buffer | null;
+    nnn: number;
+}
+
+export interface AudioCallbackInfoArg extends BaseAudioCallbackArg {
+    command: "starting" | "change" | "ending";
+    data: AudioCallbackInfo;
+}
+
+export interface AudioCallbackBufferArg extends BaseAudioCallbackArg {
+    command: "buffer_in" | "buffer_out" | "buffer_main";
+    data: AudioCallbackBuffer;
+}
+
+export type AudioCallbackArg = AudioCallbackInfoArg | AudioCallbackBufferArg;

--- a/lib/src/types/voicemeeter-types.ts
+++ b/lib/src/types/voicemeeter-types.ts
@@ -1,3 +1,5 @@
+import { IKoffiRegisteredCallback } from "koffi";
+
 import { AudioCallbackCommands } from "../lib/constants";
 
 export type VoiceMeeterTypes = "voicemeeter" | "voicemeeterBanana" | "voicemeeterPotato" | undefined;
@@ -49,6 +51,12 @@ export interface VBVMR_T_AUDIOBUFFER {
     audiobuffer_nbo: number;
     audiobuffer_r: Float32Array[];
     audiobuffer_w: Float32Array[];
+}
+
+export interface AudioCallbackState {
+    pointer: IKoffiRegisteredCallback | undefined;
+    pendingUnregister: boolean;
+    ended: boolean;
 }
 
 export interface AudioCallbackBuffer {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
             "version": "2.1.5",
             "license": "MIT",
             "dependencies": {
-                "koffi": "2.12.1",
+                "koffi": "2.13.0",
                 "winreg": "1.2.5"
             },
             "devDependencies": {
@@ -6837,11 +6837,10 @@
             }
         },
         "node_modules/koffi": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.12.1.tgz",
-            "integrity": "sha512-l0+ujtJtiXicQurXu8hpe5KAb5vn3uHkn9fsQFBev6d5zG5ERTJp60O/PC8K8zlwcd2jOeneNCkzCiIGQbgLIw==",
-            "hasInstallScript": true,
-            "license": "MIT"
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.13.0.tgz",
+            "integrity": "sha512-VqQzBC7XBVJHXA4DkmY68HbH8VTYVaBKq3MFlziI+pdJXIpd/lO4LeXKo2YpIhuTkLgXYra+dDjJOo2+yT1Tsg==",
+            "hasInstallScript": true
         },
         "node_modules/levn": {
             "version": "0.4.1",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added the ability to directly process the audio signal from voicemeeter with the audio callback functions.

- **What is the current behavior?** (You can also link to an open issue here)
Not implemented.
- **What is the new behavior (if this is a feature change)?**
Added support for registering, starting, stopping and unregistering callbacks
- **Other information**:
**This is a draft.**
I'll update this with examples+version change, after we've considered/thought about the actual implementation
 
I've implemented just the basic functionality of the [AudioCallback system](https://github.com/vburel2018/Voicemeeter-SDK/blob/3be2c1c36563afbd6df3da8436406c77d2cc1f10/VoicemeeterRemote.h#L486), supporting only one callback for now, voicemeeter allows 3 in total (in/out/main), but I'm not sure how much the library should/shouldn't handle. 
Especially since it's not really comparable to other functions. Right now it's handling quite a bit, if not all the essentials, I still need to add 3 callback support and consider using `koffi.view` to access and pass-through the external audiobuffer_r/w.

Yet, I also want to keep it light-weight since it's important for the callback to be 'real-time' without excessive delays (otherwise your audio gets fucked).

I'd personally have it way simpler than this and have the callback be completely up to the user, but maybe that's too minimal and gives the user too much power and ability to mess up (I don't mind the unlimited power 🙂 ).